### PR TITLE
feat(rpc): expose the configured node endpoint URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+* [FEATURE][rust] Added `NodeRpcClient::endpoint` and `Client::rpc_endpoint`, exposing the configured node endpoint URL without a network round-trip. ([#PR](https://github.com/0xMiden/miden-client/pull/PR))
+
 ### Fixes
 
 * [FIX][rust] RPC endpoint parsing now rejects endpoint strings that omit either the protocol or host. ([#2266](https://github.com/0xMiden/miden-client/pull/2266))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-* [FEATURE][rust] Added `NodeRpcClient::endpoint` and `Client::rpc_endpoint`, exposing the configured node endpoint URL without a network round-trip. ([#PR](https://github.com/0xMiden/miden-client/pull/PR))
+* [FEATURE][rust] Added `NodeRpcClient::endpoint` and `Client::rpc_endpoint`, exposing the configured node endpoint URL without a network round-trip. ([#2291](https://github.com/0xMiden/miden-client/pull/2291))
 
 ### Fixes
 

--- a/crates/rust-client/src/lib.rs
+++ b/crates/rust-client/src/lib.rs
@@ -498,6 +498,12 @@ impl<AUTH> Client<AUTH> {
         self.store.identifier()
     }
 
+    /// Returns the node endpoint URL the client's RPC transport is configured to talk to, if the
+    /// transport tracks one.
+    pub fn rpc_endpoint(&self) -> Option<&str> {
+        self.rpc_api.endpoint()
+    }
+
     /// Registers a [`transaction::TransactionObserver`]. Per-observer failures are logged.
     pub fn with_transaction_observer(
         &mut self,

--- a/crates/rust-client/src/rpc/mod.rs
+++ b/crates/rust-client/src/rpc/mod.rs
@@ -135,6 +135,14 @@ pub trait NodeRpcClient: Send + Sync {
     /// Returns the genesis commitment if it has been set, without fetching from the node.
     fn has_genesis_commitment(&self) -> Option<Word>;
 
+    /// Returns the node endpoint URL this client is configured to talk to, if it tracks one.
+    ///
+    /// Defaults to `None` for implementations that don't track an endpoint (e.g. test mocks); real
+    /// transports return their configured URL.
+    fn endpoint(&self) -> Option<&str> {
+        None
+    }
+
     /// Given a Proven Transaction, send it to the node for it to be included in a future block
     /// using the `/SubmitProvenTransaction` RPC endpoint.
     ///

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -372,6 +372,10 @@ impl NodeRpcClient for GrpcClient {
         *self.genesis_commitment.read()
     }
 
+    fn endpoint(&self) -> Option<&str> {
+        Some(&self.endpoint)
+    }
+
     async fn set_genesis_commitment(&self, commitment: Word) -> Result<(), RpcError> {
         // Check if already set before doing anything else
         if self.genesis_commitment.read().is_some() {
@@ -1175,6 +1179,13 @@ mod tests {
         let client = GrpcClient::new(endpoint, 10000);
         let client: Box<GrpcClient> = client.into();
         tokio::task::spawn(async move { dyn_trait_send_fut(client).await });
+    }
+
+    #[test]
+    fn endpoint_returns_the_configured_url() {
+        let endpoint = Endpoint::devnet();
+        let client = GrpcClient::new(&endpoint, 10000);
+        assert_eq!(client.endpoint(), Some(endpoint.to_string().as_str()));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Adds `NodeRpcClient::endpoint(&self) -> Option<&str>` (default `None`, overridden by `GrpcClient` to return its configured URL) and `Client::rpc_endpoint(&self) -> Option<&str>`.

## Why

Lets consumers read the endpoint a client is configured to talk to without a network round-trip or threading the URL alongside the client. The trait method has a default (`None`), so it's non-breaking for external `NodeRpcClient` implementors; mocks inherit it.

Motivating consumer: web-sdk's React layer derives the RPC endpoint from the `WebClient` itself (single source of truth) instead of a separately-stored copy in its store — see the linked web-sdk PR.
