### PR TITLE
fix(keystore): report unreadable index entries instead of dropping keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 ### Fixes
 
 * [FIX][cli] `miden-client init` now reports invalid remote prover endpoints instead of silently writing a local-prover config ([#2376](https://github.com/0xMiden/rust-sdk/pull/2376)).
+* [FIX][rust] The keystore no longer drops keys it can't read. `FilesystemKeyStore::get_account_key_commitments` returns a `DecodingError` for an index entry that isn't valid `Word` hex instead of skipping it, and `Keystore::get_keys_for_account` returns a `StorageError` when a commitment listed for an account has no stored key instead of omitting it. Both cases were previously reported as success with a short key set, so `miden-client export <ID> --account` could write a backup missing auth keys and still exit successfully.
 
 ## 0.16.0-alpha.1 (2026-07-17)
 

--- a/crates/rust-client/src/keystore/fs_keystore.rs
+++ b/crates/rust-client/src/keystore/fs_keystore.rs
@@ -119,25 +119,33 @@ impl KeyIndex {
     }
 
     /// Gets all public key commitments for an account ID.
+    ///
+    /// # Errors
+    /// - [`KeyStoreError::StorageError`] if the account has no entry in the index.
+    /// - [`KeyStoreError::DecodingError`] if any of the account's entries isn't valid [`Word`] hex.
+    ///   Callers use the returned set to enumerate an account's keys, so skipping unreadable
+    ///   entries would understate the key set instead of reporting the corrupt index.
     fn get_commitments(
         &self,
         account_id: &AccountId,
     ) -> Result<BTreeSet<PublicKeyCommitment>, KeyStoreError> {
         let account_id_hex = account_id.to_hex();
 
-        self.mappings
-            .get(&account_id_hex)
-            .map(|commitments| {
-                commitments
-                    .iter()
-                    .filter_map(|hex| {
-                        Word::try_from(hex.as_str()).ok().map(PublicKeyCommitment::from)
-                    })
-                    .collect()
+        let commitments = self.mappings.get(&account_id_hex).ok_or_else(|| {
+            KeyStoreError::StorageError(format!("account not found {account_id_hex}"))
+        })?;
+
+        commitments
+            .iter()
+            .map(|hex| {
+                Word::try_from(hex.as_str()).map(PublicKeyCommitment::from).map_err(|err| {
+                    KeyStoreError::DecodingError(format!(
+                        "invalid public key commitment {hex} listed for account \
+                         {account_id_hex} in index file: {err}"
+                    ))
+                })
             })
-            .ok_or_else(|| {
-                KeyStoreError::StorageError(format!("account not found {account_id_hex}"))
-            })
+            .collect()
     }
 }
 
@@ -362,4 +370,83 @@ fn write_secret_key_file(file_path: &Path, key: &AuthSecretKey) -> Result<(), Ke
 
 fn keystore_error(context: &str) -> impl FnOnce(std::io::Error) -> KeyStoreError {
     move |err| KeyStoreError::StorageError(format!("{context}: {err:?}"))
+}
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use miden_protocol::testing::account_id::ACCOUNT_ID_REGULAR_PRIVATE_ACCOUNT_UPDATABLE_CODE;
+
+    use super::*;
+
+    fn test_account_id() -> AccountId {
+        AccountId::try_from(ACCOUNT_ID_REGULAR_PRIVATE_ACCOUNT_UPDATABLE_CODE).unwrap()
+    }
+
+    /// Rewrites the on-disk index after applying `mutate` to it, standing in for an index file
+    /// corrupted outside the keystore.
+    fn corrupt_index_file(keys_directory: &Path, mutate: impl FnOnce(&mut KeyIndex)) {
+        let index_path = keys_directory.join(INDEX_FILE_NAME);
+        let mut index: KeyIndex =
+            serde_json::from_str(&fs::read_to_string(&index_path).unwrap()).unwrap();
+        mutate(&mut index);
+        fs::write(&index_path, serde_json::to_string_pretty(&index).unwrap()).unwrap();
+    }
+
+    #[tokio::test]
+    async fn get_account_key_commitments_rejects_malformed_index_entry() {
+        let keys_directory = tempfile::tempdir().unwrap();
+        let account_id = test_account_id();
+
+        let keystore = FilesystemKeyStore::new(keys_directory.path().to_path_buf()).unwrap();
+        let key = AuthSecretKey::new_falcon512_poseidon2();
+        keystore.add_key(&key, account_id).await.unwrap();
+
+        corrupt_index_file(keys_directory.path(), |index| {
+            index
+                .mappings
+                .get_mut(&account_id.to_hex())
+                .unwrap()
+                .insert(String::from("not-a-word-commitment"));
+        });
+
+        let keystore = FilesystemKeyStore::new(keys_directory.path().to_path_buf()).unwrap();
+        let error = keystore
+            .get_account_key_commitments(&account_id)
+            .await
+            .expect_err("an index entry that isn't valid Word hex should be reported, not skipped");
+
+        assert!(
+            matches!(error, KeyStoreError::DecodingError(_)),
+            "expected a decoding error, got: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_keys_for_account_rejects_missing_key_file() {
+        let keys_directory = tempfile::tempdir().unwrap();
+        let account_id = test_account_id();
+
+        let keystore = FilesystemKeyStore::new(keys_directory.path().to_path_buf()).unwrap();
+        let kept_key = AuthSecretKey::new_falcon512_poseidon2();
+        let deleted_key = AuthSecretKey::new_falcon512_poseidon2();
+        keystore.add_key(&kept_key, account_id).await.unwrap();
+        keystore.add_key(&deleted_key, account_id).await.unwrap();
+
+        // Delete one key file while leaving its commitment in the index.
+        let deleted_commitment = deleted_key.public_key().to_commitment();
+        fs::remove_file(key_file_path(keys_directory.path(), deleted_commitment)).unwrap();
+
+        let error = keystore
+            .get_keys_for_account(&account_id)
+            .await
+            .expect_err("a commitment whose key file is gone should be reported, not skipped");
+
+        assert!(
+            matches!(error, KeyStoreError::StorageError(_)),
+            "expected a storage error, got: {error:?}"
+        );
+    }
 }

--- a/crates/rust-client/src/keystore/mod.rs
+++ b/crates/rust-client/src/keystore/mod.rs
@@ -47,7 +47,8 @@ pub trait Keystore: TransactionAuthenticator {
 
     /// Returns all public key commitments associated with the given account ID.
     ///
-    /// Returns an error if the account is not found.
+    /// Returns an error if the account is not found, or if any of the stored commitments can't be
+    /// decoded.
     async fn get_account_key_commitments(
         &self,
         account_id: &AccountId,
@@ -67,7 +68,9 @@ pub trait Keystore: TransactionAuthenticator {
     /// followed by `get_key` for each commitment.
     ///
     /// Returns an empty vector if the account has no associated keys.
-    /// Returns an error if any key lookup fails.
+    /// Returns an error if any key lookup fails, including when a commitment associated with the
+    /// account has no stored key. Callers treat the result as the account's complete key set, so a
+    /// short vector would be indistinguishable from an account that legitimately holds fewer keys.
     async fn get_keys_for_account(
         &self,
         account_id: &AccountId,
@@ -75,9 +78,13 @@ pub trait Keystore: TransactionAuthenticator {
         let commitments = self.get_account_key_commitments(account_id).await?;
         let mut keys = Vec::with_capacity(commitments.len());
         for commitment in commitments {
-            if let Some(key) = self.get_key(commitment).await? {
-                keys.push(key);
-            }
+            let key = self.get_key(commitment).await?.ok_or_else(|| {
+                KeyStoreError::StorageError(format!(
+                    "no key stored for commitment {commitment} associated with account {}",
+                    account_id.to_hex()
+                ))
+            })?;
+            keys.push(key);
         }
         Ok(keys)
     }


### PR DESCRIPTION
## Summary

Two sites in the keystore silently drop keys they can't read, and both end
in the same user-visible outcome: `miden-client export <ID> --account`
writes a `.mac` backup with fewer auth keys than the account has, prints
success, and exits 0. The user believes they have a complete backup.

`FilesystemKeyStore::get_account_key_commitments` used
`filter_map(|hex| Word::try_from(hex).ok())`, so any index entry that isn't
valid `Word` hex was skipped. Its doc contract lists account-not-found as
the only failure. It now returns a `DecodingError` naming the bad entry.

`Keystore::get_keys_for_account` used `if let Some(key) = get_key(..)?`, so
a commitment listed in the index whose key file is gone was skipped. That
method's own doc already says it "returns an error if any key lookup fails."
It now returns a `StorageError` naming the orphaned commitment.

`export.rs` guards against a fully empty key set, but not a partial one, so
neither case was caught downstream.

## Note on behaviour change

This is stricter than before: a keystore that is already corrupt will now
fail loudly where it previously succeeded with a short key set. That seems
right for this data. A partial key set is indistinguishable from an account
that legitimately holds fewer keys, so the quiet path produces an incomplete
backup with no signal that anything is missing.

## Testing

Two regression tests in `crates/rust-client/src/keystore/fs_keystore.rs`,
both driving the public API. Verified red against the unfixed code: the
first returned one commitment instead of erroring, the second returned one
key instead of two.

    cargo test -p miden-client --lib    # 96 passed, 0 failed

`make lint` passes except for a pre-existing `typos` error in CHANGELOG.md
(`integraion`), which is on `next` and unrelated. Likewise
`cargo test -p miden-client --doc` fails on an `rpc/mod.rs` doctest that
needs the `tonic` feature; also pre-existing on `next`.

## Not included

`INDEX_VERSION` is declared but `read_from_file` never compares it to the
deserialized `version` field. Same class of bug, but fixing it means
deciding a compatibility policy (reject vs migrate), which felt like a
separate discussion. Happy to follow up.