### PR TITLE
fix settings row count errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 * [FIX][cli] `miden-client account --default none` now reports whether a default account was actually removed instead of always printing that it was. Removing an absent setting also no longer panics in debug builds ([#2439](https://github.com/0xMiden/rust-sdk/pull/2439)).
 * [FIX][cli] `miden-client address remove` now reports whether the address was actually removed instead of always printing that it was being removed.
 * [FIX][rust] `VerifyingRpcClient::get_account` now validates that the returned `AccountProof` belongs to the requested account ID, rejecting a mismatch with `RpcError::InvalidResponse` ([#2419](https://github.com/0xMiden/rust-sdk/pull/2419)).
+* [FIX][store] SQLite setting writes now return an error when SQLite reports that the affected row count is not one ([#2350](https://github.com/0xMiden/rust-sdk/issues/2350)).
 
 ## 0.16.0-alpha.1 (2026-07-17)
 

--- a/crates/rust-client/src/store/errors.rs
+++ b/crates/rust-client/src/store/errors.rs
@@ -86,6 +86,13 @@ pub enum StoreError {
     ParsingError(String),
     #[error("failed to retrieve data from the database: {0}")]
     QueryError(String),
+    #[error("setting {key:?} {operation} affected {actual} rows, expected {expected}")]
+    SettingUnexpectedRowCount {
+        operation: &'static str,
+        key: String,
+        expected: usize,
+        actual: usize,
+    },
     #[error("sparse merkle tree proof error")]
     SmtProofError(#[from] SmtProofError),
     #[error("account storage map error")]

--- a/crates/sqlite-store/src/lib.rs
+++ b/crates/sqlite-store/src/lib.rs
@@ -422,10 +422,8 @@ impl Store for SqliteStore {
     }
 
     async fn set_setting(&self, key: String, value: Vec<u8>) -> Result<(), StoreError> {
-        self.interact_with_connection(move |conn| {
-            SqliteStore::set_setting(conn, &key, &value).into_store_error()
-        })
-        .await
+        self.interact_with_connection(move |conn| SqliteStore::set_setting(conn, &key, &value))
+            .await
     }
 
     async fn get_setting(&self, key: String) -> Result<Option<Vec<u8>>, StoreError> {
@@ -452,7 +450,7 @@ impl Store for SqliteStore {
             for mutation in &mutations {
                 match mutation {
                     SettingMutation::Set { key, value } => {
-                        SqliteStore::set_setting(&tx, key, value).into_store_error()?;
+                        SqliteStore::set_setting(&tx, key, value)?;
                     },
                     SettingMutation::Remove { key } => {
                         SqliteStore::remove_setting(&tx, key)?;

--- a/crates/sqlite-store/src/settings.rs
+++ b/crates/sqlite-store/src/settings.rs
@@ -29,13 +29,21 @@ impl SqliteStore {
         conn: &Connection,
         name: &str,
         value: &T,
-    ) -> rusqlite::Result<()> {
-        let count =
-            conn.execute(insert_sql!(settings { name, value } | REPLACE), params![name, value])?;
+    ) -> Result<(), StoreError> {
+        let count = conn
+            .execute(insert_sql!(settings { name, value } | REPLACE), params![name, value])
+            .into_store_error()?;
 
-        debug_assert_eq!(count, 1);
-
-        Ok(())
+        if count == 1 {
+            Ok(())
+        } else {
+            Err(StoreError::SettingUnexpectedRowCount {
+                operation: "set",
+                key: name.to_string(),
+                expected: 1,
+                actual: count,
+            })
+        }
     }
 
     /// Returns `true` if a row was deleted, `false` if `name` wasn't present.
@@ -53,5 +61,43 @@ impl SqliteStore {
             .into_store_error()?
             .collect::<Result<Vec<String>, _>>()
             .into_store_error()
+    }
+}
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use miden_client::store::StoreError;
+    use rusqlite::Connection;
+
+    use super::SqliteStore;
+    use crate::db_management::migration::SqliteMigrator;
+
+    #[test]
+    fn set_setting_reports_unexpected_row_count() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        SqliteMigrator::client().apply(&mut conn).unwrap();
+        conn.execute_batch(
+            "CREATE TRIGGER ignore_settings_insert
+             BEFORE INSERT ON settings
+             BEGIN
+                 SELECT RAISE(IGNORE);
+             END;",
+        )
+        .unwrap();
+
+        let err = SqliteStore::set_setting(&conn, "ignored", &vec![1u8]).unwrap_err();
+
+        assert!(matches!(
+            err,
+            StoreError::SettingUnexpectedRowCount {
+                operation: "set",
+                ref key,
+                expected: 1,
+                actual: 0,
+            } if key == "ignored"
+        ));
     }
 }


### PR DESCRIPTION
Part of #2350.

Rebased this on the current `next` branch and moved the row-count check into the new `settings.rs` module. Since `remove_setting` now returns `false` for a missing key, this keeps the fix scoped to setting writes.

Checked locally:
- `RUSTC=$(rustup which --toolchain 1.96 rustc) rustup run 1.96 cargo test -p miden-client-sqlite-store set_setting_reports_unexpected_row_count`
- `RUSTFMT=$(rustup which --toolchain nightly rustfmt); "$RUSTFMT" --check crates/sqlite-store/src/settings.rs crates/sqlite-store/src/lib.rs crates/rust-client/src/store/errors.rs`
- `TOOLCHAIN_BIN=$(dirname "$(rustup which --toolchain 1.96 rustc)"); PATH="$TOOLCHAIN_BIN:$PATH" RUSTC="$TOOLCHAIN_BIN/rustc" rustup run 1.96 cargo clippy -p miden-client-sqlite-store --all-targets -- -D warnings`
- `NO_CHANGELOG_LABEL=false BASE_REF=next ./scripts/check-changelog.sh`