### PR TITLE
ci: add no migration check label

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,22 +17,6 @@ env:
   RUST_CACHE_KEY: rust-cache-2026.02.18
 
 jobs:
-  migrations:
-    name: Migrations are append-only
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Check that no released migration was modified
-        env:
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
-        run: ./scripts/check-migrations.sh
-        shell: bash
-
   unused_deps:
     name: Check for unused dependencies
     runs-on: ubuntu-latest

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   migrations:
     name: Migrations are append-only

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -1,0 +1,30 @@
+# Checks that already released SQL migrations are not edited.
+# Lives in its own workflow so that adding or removing the "no migration check" label re-evaluates
+# the check without re-running the whole lint suite.
+
+name: migrations
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  migrations:
+    name: Migrations are append-only
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Check that no released migration was modified
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          NO_MIGRATION_CHECK_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'no migration check') }}
+        run: ./scripts/check-migrations.sh
+        shell: bash

--- a/crates/sqlite-store/README.md
+++ b/crates/sqlite-store/README.md
@@ -48,7 +48,9 @@ Upgrades are forward-only. There are no down migrations.
 4. Add a `CHANGELOG.md` entry under `[store]`.
 
 `scripts/check-migrations.sh` runs in CI and fails a pull request that modifies, renames or deletes
-a file that already exists on the base branch.
+a file that already exists on the base branch. The `no migration check` label skips it, for schema
+changes that no released client can encounter yet: in that case edit the existing migration and
+update its pinned schema hash instead of adding a new file.
 
 ### Migrations that transform data
 

--- a/crates/sqlite-store/README.md
+++ b/crates/sqlite-store/README.md
@@ -46,7 +46,9 @@ Upgrades are forward-only. There are no down migrations.
 4. Add a `CHANGELOG.md` entry under `[store]`.
 
 `scripts/check-migrations.sh` runs in CI and fails a pull request that modifies, renames or deletes
-a file that already exists on the base branch.
+a file that already exists on the base branch. The `no migration check` label skips it, for schema
+changes that no released client can encounter yet: in that case edit the existing migration and
+update its pinned schema hash instead of adding a new file.
 
 ### Migrations that transform data
 

--- a/scripts/check-migrations.sh
+++ b/scripts/check-migrations.sh
@@ -5,6 +5,12 @@
 set -euo pipefail
 
 MIGRATIONS_DIR="${1:-crates/sqlite-store/src/migrations}"
+
+if [ "${NO_MIGRATION_CHECK_LABEL:-false}" = "true" ]; then
+    echo "\"no migration check\" label has been set"
+    exit 0
+fi
+
 BASE="origin/${BASE_REF:?must be set to the base branch of the pull request}"
 
 if ! git rev-parse --verify --quiet "${BASE}^{commit}" > /dev/null; then
@@ -27,5 +33,8 @@ fi
 >&2 echo "Migrations are append-only. Add a new file under \"${MIGRATIONS_DIR}\" with the next
 version prefix instead, register it in CLIENT_MIGRATIONS and append its schema hash to
 PINNED_SCHEMA_HASHES, both in crates/sqlite-store/src/db_management/migration.rs, rather than editing
-the existing entries."
+the existing entries.
+
+This behavior can be overridden by using the \"no migration check\" label, which is used for
+schema changes that no released client can encounter yet."
 exit 1

--- a/scripts/check-migrations.sh
+++ b/scripts/check-migrations.sh
@@ -5,6 +5,12 @@
 set -euo pipefail
 
 MIGRATIONS_DIR="${1:-crates/sqlite-store/src/migrations}"
+
+if [ "${NO_MIGRATION_CHECK_LABEL:-false}" = "true" ]; then
+    echo "\"no migration check\" label has been set"
+    exit 0
+fi
+
 BASE="origin/${BASE_REF:?must be set to the base branch of the pull request}"
 
 if ! git rev-parse --verify --quiet "${BASE}^{commit}" > /dev/null; then
@@ -27,5 +33,8 @@ fi
 >&2 echo "Migrations are append-only. Add a new file under \"${MIGRATIONS_DIR}\" with the next
 version prefix instead, register it in MIGRATION_SCRIPTS and append its schema hash to
 PINNED_SCHEMA_HASHES, both in crates/sqlite-store/src/db_management/utils.rs, rather than editing
-the existing entries."
+the existing entries.
+
+This behavior can be overridden by using the \"no migration check\" label, which is used for
+schema changes that no released client can encounter yet."
 exit 1


### PR DESCRIPTION
Move migration check to own file, and add `no migration check` label that allows skipping it.

Closes #2368