### PR TITLE
fix: append flag to build faucet component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-* [FIX][cli] Faucets created from the `basic-fungible-faucet` package now carry the pause flag storage slot, so minting from them no longer aborts with "storage slot with the provided name does not exist" ([#XXXX](https://github.com/0xMiden/rust-sdk/pull/XXXX)).
+* [FIX][cli] Faucets created from the `basic-fungible-faucet` package now carry the pause flag storage slot, so minting from them no longer aborts with "storage slot with the provided name does not exist" ([#2390](https://github.com/0xMiden/rust-sdk/pull/2390)).
 
 ## 0.15.5 (2026-08-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+* [FIX][cli] Faucets created from the `basic-fungible-faucet` package now carry the pause flag storage slot, so minting from them no longer aborts with "storage slot with the provided name does not exist" ([#XXXX](https://github.com/0xMiden/rust-sdk/pull/XXXX)).
+
 ## 0.15.5 (2026-08-03)
 
 ### Breaking Changes

--- a/bin/miden-cli/src/commands/new_account.rs
+++ b/bin/miden-cli/src/commands/new_account.rs
@@ -14,6 +14,7 @@ use miden_client::account::component::{
     InitStorageData,
     MIDEN_PACKAGE_EXTENSION,
     MintPolicyConfig,
+    PausableStorage,
     PolicyRegistration,
     StorageSlotSchema,
     TokenName,
@@ -433,6 +434,42 @@ fn separate_auth_components(
     Ok((auth_component, regular_components))
 }
 
+/// Restores the `is_paused` storage slot on a fungible faucet component that was instantiated
+/// from a package.
+///
+/// The faucet's code reads `is_paused`, and the typed `FungibleFaucet` component contributes the
+/// slot when it builds its storage. The storage schema published in the component's metadata does
+/// not declare that slot though, and instantiating a component from a package derives its storage
+/// exclusively from that schema. A faucet created from `basic-fungible-faucet.masp` therefore
+/// lacks `is_paused`, and every mint against it aborts in the transaction kernel with "storage
+/// slot with the provided name does not exist".
+///
+/// TODO: fix upstream instead, by declaring `PausableStorage::is_paused_slot_schema()` in
+/// `FungibleFaucet::component_metadata()`. That fixes every consumer of the package, and this
+/// workaround can then be removed.
+fn restore_faucet_pausable_slot(component: AccountComponent) -> Result<AccountComponent, CliError> {
+    if component.metadata().name() != FungibleFaucet::NAME {
+        return Ok(component);
+    }
+
+    let pausable_slot_name = PausableStorage::is_paused_slot();
+    if component.storage_slots().iter().any(|slot| slot.name() == pausable_slot_name) {
+        return Ok(component);
+    }
+
+    let mut storage_slots = component.storage_slots().to_vec();
+    storage_slots.push(PausableStorage::default().into_slot());
+
+    AccountComponent::new(
+        component.component_code().clone(),
+        storage_slots,
+        component.metadata().clone(),
+    )
+    .map_err(|err| {
+        CliError::Account(err, "failed to add the pause flag slot to the faucet component".into())
+    })
+}
+
 /// Returns `true` when the CLI should inject a default `TokenPolicyManager` for a fungible
 /// faucet account built from package components.
 ///
@@ -683,7 +720,7 @@ fn process_packages(
                 )
             })?;
 
-        account_components.push(account_component);
+        account_components.push(restore_faucet_pausable_slot(account_component)?);
     }
 
     Ok(account_components)
@@ -732,5 +769,21 @@ mod tests {
         let regular_components = vec![AccountComponent::from(BasicWallet)];
 
         assert!(!should_add_implicit_token_policy_manager(&regular_components));
+    }
+
+    #[test]
+    fn pausable_slot_is_not_added_to_non_faucet_components() {
+        let wallet = AccountComponent::from(BasicWallet);
+        let slot_count = wallet.storage_slots().len();
+
+        let restored = restore_faucet_pausable_slot(wallet).unwrap();
+
+        assert_eq!(restored.storage_slots().len(), slot_count);
+        assert!(
+            !restored
+                .storage_slots()
+                .iter()
+                .any(|slot| slot.name() == PausableStorage::is_paused_slot())
+        );
     }
 }

--- a/bin/miden-cli/tests/cli.rs
+++ b/bin/miden-cli/tests/cli.rs
@@ -1,4 +1,5 @@
 use std::env::{self, temp_dir};
+use std::fmt::Write as _;
 use std::fs::{self, File};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
@@ -310,6 +311,31 @@ async fn mint_with_untracked_account() -> Result<()> {
     // Wait until the faucet's mint transaction is committed on the node.
     // We sync for a committed transaction (not note) because the target account is untracked,
     // so the output note's tag won't be requested during sync and the note will never appear.
+    sync_until_committed_transaction(&temp_dir);
+    Ok(())
+}
+
+/// Mints from a faucet built through the plain `basic-fungible-faucet` package path, where every
+/// templated storage value comes from the init data file rather than from the
+/// `[fungible-faucet-metadata]` shortcut.
+///
+/// Both paths must yield a faucet whose storage carries every slot the faucet code reads, so the
+/// mint has to execute in the transaction kernel just like it does for a faucet built from the
+/// metadata block.
+#[tokio::test]
+async fn mint_from_package_created_faucet() -> Result<()> {
+    let temp_dir = init_cli().1;
+
+    let fungible_faucet_account_id = new_faucet_from_package_cli(&temp_dir, AccountType::Private);
+
+    sync_cli(&temp_dir);
+
+    mint_cli(
+        &temp_dir,
+        &AccountId::try_from(ACCOUNT_ID_REGULAR).unwrap().to_hex(),
+        &fungible_faucet_account_id,
+    );
+
     sync_until_committed_transaction(&temp_dir);
     Ok(())
 }
@@ -1445,6 +1471,66 @@ fn new_faucet_cli(cli_path: &Path, visibility: AccountType) -> String {
 
     let output = create_faucet_cmd.current_dir(cli_path).output().unwrap();
     assert!(output.status.success());
+
+    std::str::from_utf8(&output.stdout)
+        .unwrap()
+        .split_whitespace()
+        .skip_while(|&word| word != "-s")
+        .nth(1)
+        .unwrap()
+        .to_string()
+}
+
+/// Creates a new faucet account through the plain package path, without the
+/// `[fungible-faucet-metadata]` shortcut, using the CLI given by `cli_path`.
+///
+/// The init data is derived from the package's own storage schema so every templated value is
+/// supplied up front and the command never falls back to prompting on stdin.
+fn new_faucet_from_package_cli(cli_path: &Path, visibility: AccountType) -> String {
+    const INIT_DATA_FILENAME: &str = "package_init_data.toml";
+
+    let mut init_storage_data_toml = String::new();
+    for (value_name, requirement) in FungibleFaucet::component_metadata().schema_requirements() {
+        if requirement.default_value.is_some() {
+            continue;
+        }
+
+        let name = value_name.to_string();
+        let value = if name.ends_with(".symbol") {
+            "BTC"
+        } else if name.ends_with(".max_supply") {
+            "10000000"
+        } else if name.ends_with(".decimals") {
+            "10"
+        } else if requirement.r#type.to_string() == "bool" {
+            "false"
+        } else {
+            "0"
+        };
+
+        writeln!(init_storage_data_toml, "\"{name}\" = \"{value}\"").unwrap();
+    }
+
+    fs::write(cli_path.join(INIT_DATA_FILENAME), init_storage_data_toml).unwrap();
+
+    let mut create_faucet_cmd = cargo_bin_cmd!("miden-client");
+    create_faucet_cmd.args([
+        "new-account",
+        "-t",
+        visibility.to_string().as_str(),
+        "-p",
+        "basic-fungible-faucet",
+        "-i",
+        INIT_DATA_FILENAME,
+    ]);
+
+    let output = create_faucet_cmd.current_dir(cli_path).output().unwrap();
+    assert!(
+        output.status.success(),
+        "new_faucet_from_package_cli failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 
     std::str::from_utf8(&output.stdout)
         .unwrap()


### PR DESCRIPTION
Closes #2387

The faucet component is declaring its storage schema without the `is_paused` flag, even though the slot builder emits it. Next, the `.masp` file embeds the schema, and `from_package` derives the storage slots from it, this causes that the faucet produced misses that slot.

Minting attempts to read the flag, fails to find it and thus the kernel assertion fails.

We can fix this in the client by appending the flag slot to the already built faucet component. The actual fix is upstream, we need to declare `PausableStorage::is_paused_slot_schema()` in `FungibleFaucet::component_metadata()` so the schema stops under describing the component's storage.

**Note that this bug is not present as of the 0.16.0 pre-release, where the pausable slot was removed from the faucet component entirely, so schema and storage slots agree again.**