### PR TITLE
fix: reject zero-valued RPC limits to prevent chunks(0) panic

### DIFF
--- a/crates/rust-client/src/rpc/domain/limits.rs
+++ b/crates/rust-client/src/rpc/domain/limits.rs
@@ -3,6 +3,7 @@
 
 use core::convert::TryFrom;
 
+use alloc::format;
 use miden_tx::utils::serde::{
     ByteReader,
     ByteWriter,
@@ -88,6 +89,14 @@ fn get_param(
             field_name: param,
         },
     )?;
+    if *limit == 0 {
+        return Err(RpcConversionError::InvalidField(format!(
+            "{}.{} must be greater than zero",
+            endpoint.proto_name(),
+            param
+        )));
+    }
+
     Ok(*limit)
 }
 
@@ -121,5 +130,39 @@ mod tests {
         let deserialized = RpcLimits::read_from_bytes(&bytes).expect("deserialization failed");
 
         assert_eq!(original, deserialized);
+    }
+
+    #[test]
+    fn rejects_zero_limits_from_rpc_response() {
+        let mut proto = proto::RpcLimits::default();
+
+        proto.endpoints.insert(
+            RpcEndpoint::GetNotesById.proto_name().into(),
+            proto::RpcEndpointLimits {
+                parameters: [(String::from("note_id"), 0)].into(),
+            },
+        );
+        proto.endpoints.insert(
+            RpcEndpoint::SyncNullifiers.proto_name().into(),
+            proto::RpcEndpointLimits {
+                parameters: [(String::from("nullifier_prefix"), 1000)].into(),
+            },
+        );
+        proto.endpoints.insert(
+            RpcEndpoint::SyncTransactions.proto_name().into(),
+            proto::RpcEndpointLimits {
+                parameters: [(String::from("account_id"), 1000)].into(),
+            },
+        );
+        proto.endpoints.insert(
+            RpcEndpoint::SyncNotes.proto_name().into(),
+            proto::RpcEndpointLimits {
+                parameters: [(String::from("note_tag"), 1000)].into(),
+            },
+        );
+
+        let err = RpcLimits::try_from(proto).expect_err("zero limit should be rejected");
+
+        assert!(matches!(err, RpcConversionError::InvalidField(_)), "got {err:?}");
     }
 }

--- a/crates/rust-client/src/rpc/domain/limits.rs
+++ b/crates/rust-client/src/rpc/domain/limits.rs
@@ -1,9 +1,9 @@
 // RPC LIMITS
 // ================================================================================================
 
+use alloc::format;
 use core::convert::TryFrom;
 
-use alloc::format;
 use miden_tx::utils::serde::{
     ByteReader,
     ByteWriter,
@@ -115,6 +115,8 @@ impl TryFrom<proto::RpcLimits> for RpcLimits {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::String;
+
     use super::*;
 
     #[test]
@@ -138,25 +140,25 @@ mod tests {
 
         proto.endpoints.insert(
             RpcEndpoint::GetNotesById.proto_name().into(),
-            proto::RpcEndpointLimits {
+            proto::EndpointLimits {
                 parameters: [(String::from("note_id"), 0)].into(),
             },
         );
         proto.endpoints.insert(
             RpcEndpoint::SyncNullifiers.proto_name().into(),
-            proto::RpcEndpointLimits {
+            proto::EndpointLimits {
                 parameters: [(String::from("nullifier_prefix"), 1000)].into(),
             },
         );
         proto.endpoints.insert(
             RpcEndpoint::SyncTransactions.proto_name().into(),
-            proto::RpcEndpointLimits {
+            proto::EndpointLimits {
                 parameters: [(String::from("account_id"), 1000)].into(),
             },
         );
         proto.endpoints.insert(
             RpcEndpoint::SyncNotes.proto_name().into(),
-            proto::RpcEndpointLimits {
+            proto::EndpointLimits {
                 parameters: [(String::from("note_tag"), 1000)].into(),
             },
         );


### PR DESCRIPTION
## What changed

Reject zero-valued RPC limits while converting the node `GetLimits` response into `RpcLimits`, and add a regression test for a zero `note_id` limit.

## Why

The client uses these limits as chunk sizes for note IDs, tags, nullifier prefixes, and account IDs. Rust's `slice::chunks(0)` panics, so a malformed node response could crash the client instead of returning an RPC conversion error.

Fixes #2394

## Validation

- `git diff --check -- crates/rust-client/src/rpc/domain/limits.rs`
- `cargo test -p miden-client rejects_zero_limits_from_rpc_response -- --nocapture` could not complete locally because `miden-node-proto-build` failed before reaching this test: `remote_prover.proto is not in any include path`.
- `cargo check -p miden-client --no-default-features` hit the same dependency build-script failure.