### PR TITLE
chore: bump to protocol `0.16.0-rc4` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [BREAKING][type][rust] Added the `NoteFilter::ScriptRoots` variant, so exhaustive matches on `NoteFilter` in `Store` implementations must handle it ([#2335](https://github.com/0xMiden/rust-sdk/pull/2335)).
 * [BREAKING][behavior][rpc] The `SyncNotes` response now carries a reduced note metadata message: instead of the note's attachments commitment it carries one entry per attachment, with single-word attachments sent verbatim and larger ones sent as commitments. The client reconstructs the protocol-level `NoteMetadata` from those entries, so it requires a node that speaks this format.
 * [BREAKING][behavior][store] The SQLite base schema now declares an index on `input_notes(script_root)`. This changes the schema fingerprint, so opening a database created before this change fails with `SchemaHashMismatch` and existing stores must be recreated ([#2335](https://github.com/0xMiden/rust-sdk/pull/2335)).
+* [BREAKING][removal][rust] `miden_client::agglayer::create_bridge_account` and `miden_client::agglayer::create_agglayer_faucet` are removed. Build the accounts with `AggLayerBridge::account_builder` and `AggLayerFaucet::account_builder`, which return an `AccountBuilder` and take the account's `FeePolicyManager` explicitly; its active policy must be a `BasicConstantFeePolicy` scheduling every root in the account's `allowed_notes()`. The faucet builder additionally takes the initial token supply and the account seeding its `ADMIN` role.
 
 ### Enhancements
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2887,7 +2887,8 @@ dependencies = [
 [[package]]
 name = "miden-node-proto-build"
 version = "0.16.0-rc.1"
-source = "git+https://github.com/0xMiden/node.git?branch=next#99e7fa41b1cd329a640005a212eaf3772cdbd83b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4e8c47d752a8b6c9f475072a875799048d87038b759b47e8cb5f2767b74072c"
 dependencies = [
  "build-rs",
  "codegen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1378,7 +1378,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2038,15 +2038,6 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -2896,7 +2887,7 @@ dependencies = [
 [[package]]
 name = "miden-node-proto-build"
 version = "0.16.0-rc.1"
-source = "git+https://github.com/0xMiden/node.git?branch=jmunoz-update-protocol-0.16.0-rc4#02ec7156dd866fb907a12ccd7e473106c12d91fd"
+source = "git+https://github.com/0xMiden/node.git?branch=next#99e7fa41b1cd329a640005a212eaf3772cdbd83b"
 dependencies = [
  "build-rs",
  "codegen",
@@ -4051,7 +4042,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -4072,7 +4063,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -4552,7 +4543,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5101,10 +5092,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5916,7 +5907,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1378,7 +1378,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2335,9 +2335,9 @@ dependencies = [
 
 [[package]]
 name = "miden-agglayer"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed2916f90e07a781b0664b9e08e9a8b4e1cdd4a5d40699a54e3661c8fada8a9"
+checksum = "945d8d676a85d4e1de133aaa51280203b753af249e81c0743d7378366cc16765"
 dependencies = [
  "alloy-sol-types",
  "fs-err",
@@ -2374,9 +2374,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c580e0f6b4a1fe06aa1ebe5dfa8924ed58ab5a0d0afeb845fe0cbafd481917f"
+checksum = "727de4350d9ba263be17d9f93dc4b8d0deebabab29c3bed34f32c4af7b1cf20c"
 dependencies = [
  "env_logger",
  "log",
@@ -2392,9 +2392,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2acfd54fda86d88c08e2d4b23538c4f6011327e21a9576de88be90dc95fa77b"
+checksum = "3874c53f40656a56f74afe8e957d75667218808894ab8f5dbd91e58a8a0c3393"
 dependencies = [
  "env_logger",
  "log",
@@ -2427,9 +2427,9 @@ dependencies = [
 
 [[package]]
 name = "miden-block-prover"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3d1c7e5bb954409d647a47472add0c851f80c478fe757654405ce090765fcb"
+checksum = "47e13a9881d61a5334bdb12bdd66677b41d0d31ebff9a0e7b48e457bc1e161e4"
 dependencies = [
  "miden-protocol",
  "thiserror",
@@ -2588,9 +2588,9 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8394188e9b1fb828ad304d9984247b78660e53595f34880d8a403216a0e804e"
+checksum = "55df0c9b5fddcfc2c03c6e476bec0523328fb85090e716d1ab9a4db1d2267c67"
 dependencies = [
  "derive_more",
  "log",
@@ -2607,9 +2607,9 @@ dependencies = [
 
 [[package]]
 name = "miden-core-lib"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef7ef6c4f708261e948f0b59c85c055c4a1169f1066c04ca56a87d3c7e0ef119"
+checksum = "f1f5b4dca8d29c99859e3470ec1fadfa89506e6b349ade7fa475574e3104db85"
 dependencies = [
  "env_logger",
  "fs-err",
@@ -2638,9 +2638,9 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8bc266f7dc1f7069eb4f0786500241ad9b499d34cb5b8aa5b1a42fcb55e2b"
+checksum = "de00899e7045ee3bea78d4c4c690d8e2c14fff1f3a1ede1fb2922ed699fdda14"
 dependencies = [
  "blake3",
  "cc",
@@ -2680,9 +2680,9 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "832fa19dfec7601a3e7ca007e55e16b38e333e553f233249e00417432409674d"
+checksum = "a5b5a5c8b0fd14982e60ebd010f452b06f693b9efa116054487aff1f2657d2f4"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -2841,9 +2841,9 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa6fd0d84e932cbd8c51fd2e71c4f48dc4edea1dbef9259ff440e4212341e7d"
+checksum = "26062f2e4cb18e7fa9244f8b18fe2adea2bfe3f016431f75f80b5b98249c34f6"
 dependencies = [
  "hashbrown 0.17.1",
  "log",
@@ -2896,7 +2896,7 @@ dependencies = [
 [[package]]
 name = "miden-node-proto-build"
 version = "0.16.0-rc.1"
-source = "git+https://github.com/0xMiden/node.git?branch=next#92dd097a2835143d6e70de11cbfebc42e5f0b6bd"
+source = "git+https://github.com/0xMiden/node.git?branch=jmunoz-update-protocol-0.16.0-rc4#02ec7156dd866fb907a12ccd7e473106c12d91fd"
 dependencies = [
  "build-rs",
  "codegen",
@@ -2920,9 +2920,9 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe36161cad2d5945b81c21c55a71bcb5d36445183556908eb7196a2465e1852"
+checksum = "8653a8792d81ec1807815e5735de98d9d928f89b7bb5280ffadb848e87eb3ed3"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -2968,9 +2968,9 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b1429a0c3ac67db377fa5656937888ad89c6f7d8e6cb51afa549066d432d60"
+checksum = "57b3f6dbcea246715c7c528bbc2fbee46464493c11ac417c12c9562a229b136f"
 dependencies = [
  "hashbrown 0.17.1",
  "itertools 0.15.0",
@@ -2989,9 +2989,9 @@ dependencies = [
 
 [[package]]
 name = "miden-project"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aff0af79739a77d0128a307811cf6d1d134d14637fd2295d44eb7c4af28378d"
+checksum = "e02ac82735cd86ea17fcf8614496ce7e462f3e80dbc1113bf821e8197dcda49d"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -3006,9 +3006,9 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "277cfbf96f95a422d9a8c4fa54bc37ba1ecffd77e3c628a84bcc259936201fdc"
+checksum = "e275feebbe9c2458c5877c5f2a03b8e2152831ce956376f015fc4c50acfffb50"
 dependencies = [
  "bech32",
  "fs-err",
@@ -3037,9 +3037,9 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol-build-utils"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07569c89b4bd503b83db7afd5f9c8ec2e33406b5cf157f08ca50957c658d6d1f"
+checksum = "6a35f63db32f2e7ea9fc47abf17023aa509beadd77b6dffc4efff385eef4634b"
 dependencies = [
  "fs-err",
  "miden-assembly",
@@ -3053,9 +3053,9 @@ dependencies = [
 
 [[package]]
 name = "miden-prover"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86609ed83aa69f23cd8dfe7391dfe5d16cd9a160f2922c3eb230e44c7c39aed7"
+checksum = "d29bbc158dc3cf2498e351cd691192d362f67873b5b197d6b23c207c956caa60"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -3090,9 +3090,9 @@ dependencies = [
 
 [[package]]
 name = "miden-standards"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6706455ef46e5ec988728e2b161e6b30badfcb2e5927f6f9032b2e37269107"
+checksum = "d309c7d728eccc884e18ff8bb020656dfaf3547ac2475115bea3a4bdd200c0a9"
 dependencies = [
  "bon",
  "miden-assembly",
@@ -3129,9 +3129,9 @@ dependencies = [
 
 [[package]]
 name = "miden-testing"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56c7af2c5776c27307a2de05e8175cde00c1f6fc35be6f4ce7395f7d6ae9cb"
+checksum = "7e330412635cc28f7076b99a46829e5391224d9d57c31e95d2ba430b1c068391"
 dependencies = [
  "anyhow",
  "itertools 0.15.0",
@@ -3150,9 +3150,9 @@ dependencies = [
 
 [[package]]
 name = "miden-tx"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27a155a881004695c5ecc7c432967babf58ade522e55c200123aaf99d337808c"
+checksum = "b2a33858c9e0dd18959949a10e61883712faafa2857cd1f39d641deae783e28e"
 dependencies = [
  "bon",
  "miden-agglayer",
@@ -3165,9 +3165,9 @@ dependencies = [
 
 [[package]]
 name = "miden-tx-batch"
-version = "0.16.0-rc.3"
+version = "0.16.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d90956b0f9f7dcacacbbe4970f1ca9e5077ed6f9d4be69f14207ff9a63723"
+checksum = "ce1333fd5d5eed16e667af4340dc4ecea3c7dbd6020c95db7382e6f5ee26f390"
 dependencies = [
  "miden-processor",
  "miden-protocol",
@@ -3212,9 +3212,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579fdffa79eb4e9d90f53ee6cc29d7122b50b095c388a0f4ca1e1f6e04df7faf"
+checksum = "0fa9c0af7dab7842819c02ef386ed1640884db5c2efa32d30da7d4739548f70e"
 dependencies = [
  "lock_api",
  "loom",
@@ -3224,9 +3224,9 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a6cf11175c58139dd15330caf77c8462f742bfc73d7e0216c8ece45e53f90f2"
+checksum = "900c0473191ecbe2328e3d6550571f0b1ab42d1417f43c1d98a50cafc3ae4ff1"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -4552,7 +4552,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5104,7 +5104,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5916,7 +5916,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ miden-tx        = { default-features = false, version = "0.16.0-rc.4" }
 miden-tx-batch  = { default-features = false, version = "0.16.0-rc.4" }
 
 # Miden node dependencies
-miden-node-proto-build           = { branch = "jmunoz-update-protocol-0.16.0-rc4", default-features = false, git = "https://github.com/0xMiden/node.git" } # TODO: switch to rc.4 once available
+miden-node-proto-build           = { branch = "next", default-features = false, git = "https://github.com/0xMiden/node.git" } # TODO: switch to rc.4 once available
 miden-note-transport-proto-build = { default-features = false, version = "0.5.0-alpha.1" }
 
 # Miden debug dependency

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ miden-tx        = { default-features = false, version = "0.16.0-rc.4" }
 miden-tx-batch  = { default-features = false, version = "0.16.0-rc.4" }
 
 # Miden node dependencies
-miden-node-proto-build           = { branch = "next", default-features = false, git = "https://github.com/0xMiden/node.git" } # TODO: switch to rc.4 once available
+miden-node-proto-build           = { default-features = false, version = "0.16.0-rc.1" }
 miden-note-transport-proto-build = { default-features = false, version = "0.5.0-alpha.1" }
 
 # Miden debug dependency

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,20 +40,20 @@ miden-client              = { default-features = false, path = "crates/rust-clie
 miden-client-sqlite-store = { default-features = false, path = "crates/sqlite-store", version = "0.16.0-rc.1" }
 
 # Miden protocol dependencies
-miden-agglayer  = { default-features = false, version = "0.16.0-rc.3" }
-miden-protocol  = { default-features = false, version = "0.16.0-rc.3" }
-miden-standards = { default-features = false, version = "0.16.0-rc.3" }
-miden-testing   = { default-features = false, version = "0.16.0-rc.3" }
-miden-tx        = { default-features = false, version = "0.16.0-rc.3" }
-miden-tx-batch  = { default-features = false, version = "0.16.0-rc.3" }
+miden-agglayer  = { default-features = false, version = "0.16.0-rc.4" }
+miden-protocol  = { default-features = false, version = "0.16.0-rc.4" }
+miden-standards = { default-features = false, version = "0.16.0-rc.4" }
+miden-testing   = { default-features = false, version = "0.16.0-rc.4" }
+miden-tx        = { default-features = false, version = "0.16.0-rc.4" }
+miden-tx-batch  = { default-features = false, version = "0.16.0-rc.4" }
 
 # Miden node dependencies
-miden-node-proto-build           = { branch = "next", default-features = false, git = "https://github.com/0xMiden/node.git" } # TODO: switch to rc.3 once available
+miden-node-proto-build           = { branch = "jmunoz-update-protocol-0.16.0-rc4", default-features = false, git = "https://github.com/0xMiden/node.git" } # TODO: switch to rc.4 once available
 miden-note-transport-proto-build = { default-features = false, version = "0.5.0-alpha.1" }
 
 # Miden debug dependency
 miden-debug     = { default-features = false, features = ["dap", "std"], version = "0.10" }
-miden-processor = { default-features = false, version = "0.29" }
+miden-processor = { default-features = false, version = "0.29.1" }
 
 # External dependencies
 anyhow             = { default-features = false, version = "1.0" }

--- a/bin/integration-tests/Cargo.toml
+++ b/bin/integration-tests/Cargo.toml
@@ -19,7 +19,7 @@ path = "tests/integration.rs"
 
 [dependencies]
 # Workspace dependencies
-miden-agglayer            = { workspace = true }
+miden-agglayer            = { features = ["std", "testing"], workspace = true }
 miden-client              = { features = ["std", "testing", "tonic"], workspace = true }
 miden-client-sqlite-store = { workspace = true }
 miden-protocol            = { default-features = false, features = ["testing"], workspace = true }

--- a/bin/integration-tests/src/tests/agglayer/agglayer_bridge_in_out.rs
+++ b/bin/integration-tests/src/tests/agglayer/agglayer_bridge_in_out.rs
@@ -22,15 +22,16 @@ extern crate alloc;
 
 use alloc::vec;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
+use miden_agglayer::testing::zero_fee_policy_manager;
 use miden_agglayer::{
+    AggLayerFaucet,
     B2AggNote,
     ClaimNote,
     ClaimNoteStorage,
     ConfigAggBridgeNote,
     ConversionMetadata,
     UpdateGerNote,
-    create_agglayer_faucet,
 };
 use miden_client::Felt;
 use miden_client::account::AccountType;
@@ -131,13 +132,18 @@ pub async fn test_agglayer_bridge_in_out(client_config: ClientConfig) -> Result<
         },
         None => {
             let faucet_seed = bridge_admin.client.rng().draw_word();
-            let faucet = create_agglayer_faucet(
+            let faucet = AggLayerFaucet::account_builder(
                 faucet_seed,
                 "AGG",
                 12,
                 Felt::from(1_000_000_000u32),
+                Felt::ZERO,
+                bridge_admin_id,
                 bridge_id,
-            );
+                zero_fee_policy_manager(AggLayerFaucet::allowed_notes()),
+            )
+            .build()
+            .context("failed to build agglayer faucet account")?;
             let faucet_id = faucet.id();
             println!("[bridge_in_out] Creating runtime faucet: {faucet_id}");
             for pair in [&mut bridge_admin, &mut ger_manager, &mut user] {

--- a/bin/integration-tests/src/tests/agglayer/mod.rs
+++ b/bin/integration-tests/src/tests/agglayer/mod.rs
@@ -2,7 +2,8 @@ use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use miden_agglayer::{BridgeRoles, create_bridge_account};
+use miden_agglayer::testing::zero_fee_policy_manager;
+use miden_agglayer::{AggLayerBridge, BridgeRoles};
 use miden_client::Deserializable;
 use miden_client::account::{AccountFile, AccountId, AccountType};
 use miden_client::auth::RPO_FALCON_SCHEME_ID;
@@ -232,8 +233,15 @@ pub async fn setup_core_accounts(
         BTreeSet::from([ger_manager_account.id()]),
     )
     .context("failed to build bridge roles")?;
-    let bridge_account =
-        create_bridge_account(bridge_seed, bridge_admin_account.id(), roles, MIDEN_NETWORK_ID);
+    let bridge_account = AggLayerBridge::account_builder(
+        bridge_seed,
+        bridge_admin_account.id(),
+        roles,
+        MIDEN_NETWORK_ID,
+        zero_fee_policy_manager(AggLayerBridge::allowed_notes()),
+    )
+    .build()
+    .context("failed to build bridge account")?;
     println!("[setup]   bridge admin:  {}", bridge_admin_account.id());
     println!("[setup]   GER manager:   {}", ger_manager_account.id());
     println!("[setup]   bridge:        {}", bridge_account.id());

--- a/crates/testing/test-node-genesis/Cargo.toml
+++ b/crates/testing/test-node-genesis/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/bin/gen-genesis.rs"
 
 [dependencies]
 # Miden dependencies
-miden-agglayer  = { workspace = true }
+miden-agglayer  = { features = ["std", "testing"], workspace = true }
 miden-protocol  = { features = ["std", "testing"], workspace = true }
 miden-standards = { features = ["std", "testing"], workspace = true }
 

--- a/crates/testing/test-node-genesis/src/agglayer.rs
+++ b/crates/testing/test-node-genesis/src/agglayer.rs
@@ -5,7 +5,8 @@ use std::collections::BTreeSet;
 
 use ::rand::{RngExt, random};
 use anyhow::{Context, Result};
-use miden_agglayer::{BridgeRoles, create_agglayer_faucet, create_bridge_account};
+use miden_agglayer::testing::zero_fee_policy_manager;
+use miden_agglayer::{AggLayerBridge, AggLayerFaucet, BridgeRoles};
 use miden_protocol::account::auth::{AuthScheme, AuthSecretKey};
 use miden_protocol::account::{
     Account,
@@ -76,15 +77,33 @@ pub fn create_agglayer_genesis_accounts() -> Result<AgglayerGenesisAccounts> {
         BTreeSet::from([ger_account.id()]),
     )
     .context("failed to build bridge roles")?;
-    let bridge = create_bridge_account(bridge_seed, admin_account.id(), roles, MIDEN_NETWORK_ID);
+    let bridge = AggLayerBridge::account_builder(
+        bridge_seed,
+        admin_account.id(),
+        roles,
+        MIDEN_NETWORK_ID,
+        zero_fee_policy_manager(AggLayerBridge::allowed_notes()),
+    )
+    .build()
+    .context("failed to build bridge account")?;
     let bridge = set_nonce_to_one(bridge);
 
     // 4. Create and deploy the Faucet. In protocol 0.15 the faucet no longer stores conversion
     // metadata (origin token address, network, scale, metadata hash); that data lives on the
     // bridge's `faucet_metadata_map` and is written by the CONFIG_AGG_BRIDGE note at test time.
     let faucet_seed: Word = rng.random::<[u32; 4]>().map(Felt::from).into();
-    let faucet =
-        create_agglayer_faucet(faucet_seed, "AGG", 12, Felt::from(1_000_000_000u32), bridge.id());
+    let faucet = AggLayerFaucet::account_builder(
+        faucet_seed,
+        "AGG",
+        12,
+        Felt::from(1_000_000_000u32),
+        Felt::ZERO,
+        admin_account.id(),
+        bridge.id(),
+        zero_fee_policy_manager(AggLayerFaucet::allowed_notes()),
+    )
+    .build()
+    .context("failed to build agglayer faucet account")?;
     let faucet = set_nonce_to_one(faucet);
 
     let admin_file = AccountFile::new(admin_account, vec![admin_secret]);


### PR DESCRIPTION
Bump protocol to latest release candidate