### PR TITLE
fix(cli): preserve custom --network endpoint case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@
 
 ### Fixes
 
+* [FIX][cli] Preserved the original case of custom RPC endpoint URLs passed to
+  `miden-client init --network` ([#2403](https://github.com/0xMiden/rust-sdk/issues/2403)).
 * [FIX][cli] `miden-client init` now reports invalid remote prover endpoints instead of silently writing a local-prover config ([#2376](https://github.com/0xMiden/rust-sdk/pull/2376)).
 * [FIX][rust] `VerifyingRpcClient::sync_transactions` now validates that every returned transaction record's account ID was actually requested, rejecting mismatches with `RpcError::InvalidResponse` ([#2372](https://github.com/0xMiden/rust-sdk/issues/2372)).
 * [FIX][rust] `Client::prove_transaction_with` now checks that the `TransactionProver` returned a proof of the transaction it was asked to prove, rejecting a mismatch with the new `ClientError::MismatchedProvenTransaction` ([#2391](https://github.com/0xMiden/rust-sdk/pull/2391)).

--- a/bin/miden-cli/src/config.rs
+++ b/bin/miden-cli/src/config.rs
@@ -539,7 +539,7 @@ impl FromStr for Network {
             "devnet" => Ok(Network::Devnet),
             "localhost" => Ok(Network::Localhost),
             "testnet" => Ok(Network::Testnet),
-            custom => Ok(Network::Custom(custom.to_string())),
+            _ => Ok(Network::Custom(s.to_string())),
         }
     }
 }
@@ -554,5 +554,26 @@ impl Network {
             Network::Localhost => Endpoint::default().to_string(),
             Network::Testnet => Endpoint::testnet().to_string(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Network;
+
+    #[test]
+    fn network_from_str_preserves_custom_endpoint_case() {
+        let endpoint = "https://rpc.example.com/MyOrg/CaseSensitivePath";
+
+        let network = endpoint.parse::<Network>().unwrap();
+
+        assert!(matches!(network, Network::Custom(custom) if custom == endpoint));
+    }
+
+    #[test]
+    fn network_from_str_keeps_named_networks_case_insensitive() {
+        assert!(matches!("DEVNET".parse::<Network>().unwrap(), Network::Devnet));
+        assert!(matches!("LocalHost".parse::<Network>().unwrap(), Network::Localhost));
+        assert!(matches!("testNET".parse::<Network>().unwrap(), Network::Testnet));
     }
 }


### PR DESCRIPTION
Fixes #2403.

## Summary
- keeps the named `devnet`, `testnet`, and `localhost` network values case-insensitive
- preserves the original user-provided string for custom `miden-client init --network` RPC endpoints
- adds unit coverage for custom endpoint case preservation and named-network case-insensitive parsing
- adds a changelog entry for the CLI bug fix

## Why
The parser lowercased the input before matching known network names, then stored the already-lowercased string in the custom endpoint branch. That silently changed custom URLs with case-sensitive path segments or tokens.

## Testing
- `cargo fmt`

Attempted but blocked before reaching this change:
- `cargo test -p miden-client-cli network_from_str`
- `cargo clippy -p miden-client-cli -- -D warnings`

Both commands fail while building `miden-node-proto-build` from the `node` git dependency with:

```text
file 'C:\Users\omer\.cargo\git\checkouts\node-24ab1e46c2d0e30a\92dd097\proto\proto\remote_prover.proto' is not in any include path
```

The file exists locally at that path, so this appears to be a dependency build-script/include-path issue in this Windows environment rather than a failure in the changed CLI parser code.