### PR TITLE
fix(rpc): validate a stored transaction encryption key on decode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* [FIX][rust] Added validation of cached transaction encryption keys during deserialization. Unsupported encryption schemes and empty or oversized key IDs are rejected before reading the key ID bytes ([#2411](https://github.com/0xMiden/rust-sdk/pull/2411)).
 * [FIX][cli] `miden-client import` now rejects invocations without a file path instead of silently succeeding ([#2450](https://github.com/0xMiden/rust-sdk/pull/2450)).
 
 ## 0.16.0 (2026-09-07)

--- a/bin/integration-tests/src/tests/network_fpi.rs
+++ b/bin/integration-tests/src/tests/network_fpi.rs
@@ -129,10 +129,25 @@ pub async fn test_network_fpi(client_config: ClientConfig) -> Result<()> {
 
     execute_tx_and_sync(&mut client2, sender_account.id(), tx_request).await?;
 
-    wait_for_blocks(&mut client2, 2).await;
+    // The node runs the network transaction some blocks after the note is committed. The number of
+    // blocks depends on the proving time of the node, so poll the counter instead of waiting for a
+    // fixed number of blocks. A counter value of 1 shows that the note script ran to completion, so
+    // the FPI succeeded.
+    let expected_counter = Word::from([Felt::from(1u32), ZERO, ZERO, ZERO]);
+    for _ in 0..10 {
+        let updated_network_account = client2
+            .test_rpc_api()
+            .get_account_details(target_network_account.id())
+            .await?
+            .with_context(|| "account details not available")?;
 
-    // get the updated network account to check that the counter value was updated (meaning that the
-    // note was executed successfully, so the FPI was successful)
+        if updated_network_account.storage().get_item(&COUNTER_SLOT_NAME)? == expected_counter {
+            return Ok(());
+        }
+
+        wait_for_blocks(&mut client2, 1).await;
+    }
+
     let updated_network_account = client2
         .test_rpc_api()
         .get_account_details(target_network_account.id())
@@ -141,7 +156,8 @@ pub async fn test_network_fpi(client_config: ClientConfig) -> Result<()> {
 
     assert_eq!(
         updated_network_account.storage().get_item(&COUNTER_SLOT_NAME)?,
-        Word::from([Felt::from(1u32), ZERO, ZERO, ZERO])
+        expected_counter,
+        "network account counter was not incremented by the FPI note"
     );
 
     Ok(())

--- a/crates/rust-client/src/rpc/encryption.rs
+++ b/crates/rust-client/src/rpc/encryption.rs
@@ -160,10 +160,31 @@ impl Serializable for TransactionEncryptionKey {
 }
 
 impl Deserializable for TransactionEncryptionKey {
+    /// Decoding is the type's second constructor, so it holds the same line as
+    /// [`AttestedTransactionEncryptionKey::verify`]: a stored key that verification would have
+    /// rejected does not decode. The attestation itself cannot be rechecked here, since it is not
+    /// serialized and the trust anchors are not available, but the invariants that do not depend on
+    /// it are enforced.
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let scheme = source.read_u32()?;
+        if scheme != SUPPORTED_SCHEME {
+            return Err(DeserializationError::InvalidValue(format!(
+                "unsupported IES scheme '{scheme}'"
+            )));
+        }
+
         let key_id_len = source.read_usize()?;
+        // Checked before reading so a corrupt length cannot ask for a large allocation.
+        if key_id_len > MAX_KEY_ID_LEN {
+            return Err(DeserializationError::InvalidValue(format!(
+                "encryption key id is {key_id_len} bytes, which exceeds the maximum of \
+                 {MAX_KEY_ID_LEN}"
+            )));
+        }
         let key_id = source.read_vec(key_id_len)?;
+        validate_key_id(&key_id, "encryption key id")
+            .map_err(|err| DeserializationError::InvalidValue(err.to_string()))?;
+
         let public_key = PublicKey::read_from(source)?;
         let genesis_commitment = Word::read_from(source)?;
 
@@ -474,6 +495,50 @@ mod tests {
     use super::*;
 
     const TEST_KEY_ID: [u8; 4] = [0xde, 0xad, 0xbe, 0xef];
+
+    /// A key the store already holds must still decode unchanged.
+    #[test]
+    fn a_verified_key_round_trips() {
+        let (key, _) = key_pair();
+
+        let decoded = TransactionEncryptionKey::read_from_bytes(&key.to_bytes())
+            .expect("a verified key must decode");
+
+        assert_eq!(decoded, key);
+    }
+
+    /// `verify` rejects a scheme it does not support, so decoding must reject it too rather than
+    /// hand the seal path a key that never passed verification.
+    #[test]
+    fn deserialization_rejects_an_unsupported_scheme() {
+        let (key, _) = key_pair();
+        let stored = TransactionEncryptionKey { scheme: SUPPORTED_SCHEME + 1, ..key }.to_bytes();
+
+        let err = TransactionEncryptionKey::read_from_bytes(&stored)
+            .expect_err("an unsupported scheme must be rejected");
+
+        assert!(matches!(err, DeserializationError::InvalidValue(_)), "unexpected error: {err}");
+    }
+
+    /// Same for the key id bounds `verify` enforces through `validate_key_id`.
+    #[test]
+    fn deserialization_rejects_a_malformed_key_id() {
+        let (key, _) = key_pair();
+
+        for key_id in [Vec::new(), vec![0u8; MAX_KEY_ID_LEN + 1]] {
+            let len = key_id.len();
+            let stored = TransactionEncryptionKey { key_id, ..key.clone() }.to_bytes();
+
+            let err = TransactionEncryptionKey::read_from_bytes(&stored)
+                .err()
+                .unwrap_or_else(|| panic!("a {len}-byte key id must be rejected"));
+
+            assert!(
+                matches!(err, DeserializationError::InvalidValue(_)),
+                "unexpected error: {err}"
+            );
+        }
+    }
 
     fn rng() -> ChaCha20Rng {
         ChaCha20Rng::seed_from_u64(0xface)

--- a/crates/rust-client/src/rpc/encryption.rs
+++ b/crates/rust-client/src/rpc/encryption.rs
@@ -30,7 +30,7 @@
 //! The canonical definitions live in the node's `miden_node_proto::domain::encryption`. This module
 //! is a hand-maintained mirror of them, because that is a node crate and this client is `no_std`.
 
-use alloc::string::ToString;
+use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
 use miden_protocol::block::{BlockNumber, ValidatorKeys};
@@ -89,8 +89,8 @@ const MAX_KEY_ID_LEN: usize = 64;
 /// Holds public key material only, and is shared by every validator in the set; the matching secret
 /// never leaves the validators.
 ///
-/// Only [`AttestedTransactionEncryptionKey::verify`] constructs one, so a key that reaches the seal
-/// path has necessarily been vouched for by a chain-recognized validator.
+/// RPC responses can only construct one through [`AttestedTransactionEncryptionKey::verify`].
+/// Deserialization revalidates the scheme and key ID of cached keys.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TransactionEncryptionKey {
     scheme: u32,
@@ -160,31 +160,12 @@ impl Serializable for TransactionEncryptionKey {
 }
 
 impl Deserializable for TransactionEncryptionKey {
-    /// Decoding is the type's second constructor, so it holds the same line as
-    /// [`AttestedTransactionEncryptionKey::verify`]: a stored key that verification would have
-    /// rejected does not decode. The attestation itself cannot be rechecked here, since it is not
-    /// serialized and the trust anchors are not available, but the invariants that do not depend on
-    /// it are enforced.
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let scheme = source.read_u32()?;
-        if scheme != SUPPORTED_SCHEME {
-            return Err(DeserializationError::InvalidValue(format!(
-                "unsupported IES scheme '{scheme}'"
-            )));
-        }
-
         let key_id_len = source.read_usize()?;
-        // Checked before reading so a corrupt length cannot ask for a large allocation.
-        if key_id_len > MAX_KEY_ID_LEN {
-            return Err(DeserializationError::InvalidValue(format!(
-                "encryption key id is {key_id_len} bytes, which exceeds the maximum of \
-                 {MAX_KEY_ID_LEN}"
-            )));
-        }
-        let key_id = source.read_vec(key_id_len)?;
-        validate_key_id(&key_id, "encryption key id")
-            .map_err(|err| DeserializationError::InvalidValue(err.to_string()))?;
+        validate_key_metadata(scheme, key_id_len).map_err(DeserializationError::InvalidValue)?;
 
+        let key_id = source.read_vec(key_id_len)?;
         let public_key = PublicKey::read_from(source)?;
         let genesis_commitment = Word::read_from(source)?;
 
@@ -267,16 +248,11 @@ impl AttestedTransactionEncryptionKey {
         genesis_commitment: Word,
         validator_keys: &ValidatorKeys,
     ) -> Result<TransactionEncryptionKey, RpcError> {
-        if self.scheme != SUPPORTED_SCHEME {
-            return Err(RpcError::TransactionEncryptionKeyRejected(format!(
-                "unsupported IES scheme '{}'",
-                self.scheme
-            )));
-        }
-
-        validate_key_id(&self.key_id, "encryption key id")?;
+        validate_key_metadata(self.scheme, self.key_id.len())
+            .map_err(RpcError::TransactionEncryptionKeyRejected)?;
         if let Some(next) = &self.next_key {
-            validate_key_id(&next.key_id, "next encryption key id")?;
+            validate_key_id_len(next.key_id.len(), "next encryption key id")
+                .map_err(RpcError::TransactionEncryptionKeyRejected)?;
         }
 
         let commitment = attestation_commitment(
@@ -312,19 +288,22 @@ impl AttestedTransactionEncryptionKey {
     }
 }
 
-/// Rejects a served key identifier that is empty or longer than [`MAX_KEY_ID_LEN`].
-///
-/// Mirrors the validator's `validate_key_id` so the client refuses a key the node itself would
-/// never serve.
-fn validate_key_id(key_id: &[u8], field: &str) -> Result<(), RpcError> {
-    if key_id.is_empty() {
-        return Err(RpcError::TransactionEncryptionKeyRejected(format!("{field} is empty")));
+fn validate_key_metadata(scheme: u32, key_id_len: usize) -> Result<(), String> {
+    if scheme != SUPPORTED_SCHEME {
+        return Err(format!("unsupported IES scheme '{scheme}'"));
     }
-    if key_id.len() > MAX_KEY_ID_LEN {
-        return Err(RpcError::TransactionEncryptionKeyRejected(format!(
-            "{field} is {} bytes, which exceeds the maximum of {MAX_KEY_ID_LEN}",
-            key_id.len()
-        )));
+
+    validate_key_id_len(key_id_len, "encryption key id")
+}
+
+fn validate_key_id_len(key_id_len: usize, field: &str) -> Result<(), String> {
+    if key_id_len == 0 {
+        return Err(format!("{field} is empty"));
+    }
+    if key_id_len > MAX_KEY_ID_LEN {
+        return Err(format!(
+            "{field} is {key_id_len} bytes, which exceeds the maximum of {MAX_KEY_ID_LEN}"
+        ));
     }
     Ok(())
 }
@@ -496,47 +475,27 @@ mod tests {
 
     const TEST_KEY_ID: [u8; 4] = [0xde, 0xad, 0xbe, 0xef];
 
-    /// A key the store already holds must still decode unchanged.
     #[test]
-    fn a_verified_key_round_trips() {
+    fn transaction_encryption_key_deserialization_validates_metadata() {
         let (key, _) = key_pair();
+        assert_eq!(TransactionEncryptionKey::read_from_bytes(&key.to_bytes()).unwrap(), key);
 
-        let decoded = TransactionEncryptionKey::read_from_bytes(&key.to_bytes())
-            .expect("a verified key must decode");
-
-        assert_eq!(decoded, key);
-    }
-
-    /// `verify` rejects a scheme it does not support, so decoding must reject it too rather than
-    /// hand the seal path a key that never passed verification.
-    #[test]
-    fn deserialization_rejects_an_unsupported_scheme() {
-        let (key, _) = key_pair();
-        let stored = TransactionEncryptionKey { scheme: SUPPORTED_SCHEME + 1, ..key }.to_bytes();
-
-        let err = TransactionEncryptionKey::read_from_bytes(&stored)
-            .expect_err("an unsupported scheme must be rejected");
-
-        assert!(matches!(err, DeserializationError::InvalidValue(_)), "unexpected error: {err}");
-    }
-
-    /// Same for the key id bounds `verify` enforces through `validate_key_id`.
-    #[test]
-    fn deserialization_rejects_a_malformed_key_id() {
-        let (key, _) = key_pair();
-
-        for key_id in [Vec::new(), vec![0u8; MAX_KEY_ID_LEN + 1]] {
-            let len = key_id.len();
-            let stored = TransactionEncryptionKey { key_id, ..key.clone() }.to_bytes();
-
-            let err = TransactionEncryptionKey::read_from_bytes(&stored)
-                .err()
-                .unwrap_or_else(|| panic!("a {len}-byte key id must be rejected"));
-
-            assert!(
-                matches!(err, DeserializationError::InvalidValue(_)),
-                "unexpected error: {err}"
-            );
+        let invalid_keys = [
+            TransactionEncryptionKey {
+                scheme: SUPPORTED_SCHEME + 1,
+                ..key.clone()
+            },
+            TransactionEncryptionKey { key_id: Vec::new(), ..key.clone() },
+            TransactionEncryptionKey {
+                key_id: vec![0; MAX_KEY_ID_LEN + 1],
+                ..key
+            },
+        ];
+        for key in invalid_keys {
+            assert!(matches!(
+                TransactionEncryptionKey::read_from_bytes(&key.to_bytes()),
+                Err(DeserializationError::InvalidValue(_))
+            ));
         }
     }
 


### PR DESCRIPTION
TransactionEncryptionKey documents verify as its only constructor, so a key that
reaches the seal path has been vouched for by a chain-recognized validator.
Deserializable is a second constructor and it skipped both checks verify makes,
the IES scheme and the key id bounds.

The key is cached in the store after verification and read back through
Deserializable, and the cached value is never re-verified, so a corrupt row
decoded into a key the seal path treated as verified.

The attestation itself cannot be rechecked on decode, since it is not serialized
and the trust anchors are not there, but the invariants that do not depend on it
are now enforced. The key id length is bounded before the read so a corrupt
length cannot ask for a large allocation.

Three tests: a verified key still round-trips, an unsupported scheme is
rejected, and an empty or oversized key id is rejected. The last two fail on next.