### PR TITLE
fix(cli): print the note sender instead of the tag in `notes --show`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * [FIX][cli] `miden-client init` now reports invalid remote prover endpoints instead of silently writing a local-prover config ([#2376](https://github.com/0xMiden/rust-sdk/pull/2376)).
 * [FIX][rust] `VerifyingRpcClient::sync_transactions` now validates that every returned transaction record's account ID was actually requested, rejecting mismatches with `RpcError::InvalidResponse` ([#2372](https://github.com/0xMiden/rust-sdk/issues/2372)).
 * [FIX][rust] `Client::prove_transaction_with` now checks that the `TransactionProver` returned a proof of the transaction it was asked to prove, rejecting a mismatch with the new `ClientError::MismatchedProvenTransaction` ([#2391](https://github.com/0xMiden/rust-sdk/pull/2391)).
+* [FIX][cli] `miden-client notes --show` now prints the note sender in the `Sender` row; it was printing the note tag there ([#2412](https://github.com/0xMiden/rust-sdk/pull/2412)).
 
 ## 0.16.0-alpha.1 (2026-07-17)
 

--- a/bin/miden-cli/src/commands/notes.rs
+++ b/bin/miden-cli/src/commands/notes.rs
@@ -505,7 +505,7 @@ fn note_summary(
     let note_tag_str = note_metadata.map_or("-".to_string(), |metadata| metadata.tag().to_string());
 
     let note_sender_str =
-        note_metadata.map_or("-".to_string(), |metadata| metadata.tag().to_string());
+        note_metadata.map_or("-".to_string(), |metadata| metadata.sender().to_string());
 
     CliNoteSummary {
         id: id_str,
@@ -518,5 +518,50 @@ fn note_summary(
         tag: note_tag_str,
         sender: note_sender_str,
         exportable: output_note_record.is_some(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use miden_client::Word;
+    use miden_client::account::AccountId;
+    use miden_client::note::{
+        Note,
+        NoteAssets,
+        NoteRecipient,
+        NoteStorage,
+        NoteTag,
+        NoteType,
+        PartialNoteMetadata,
+        StandardNote,
+    };
+    use miden_client::store::InputNoteRecord;
+    use miden_client::testing::account_id::ACCOUNT_ID_REGULAR_PRIVATE_ACCOUNT_UPDATABLE_CODE;
+
+    use super::note_summary;
+
+    /// The sender and the tag come from separate metadata fields, and a tag doesn't have to encode
+    /// the sender, so the summary must read each from its own field.
+    #[test]
+    fn note_summary_reads_the_sender_and_the_tag_from_their_own_fields() {
+        let sender =
+            AccountId::try_from(ACCOUNT_ID_REGULAR_PRIVATE_ACCOUNT_UPDATABLE_CODE).unwrap();
+        let tag = NoteTag::new(42);
+
+        let note = Note::new(
+            NoteAssets::new(vec![]).unwrap(),
+            PartialNoteMetadata::new(sender, NoteType::Public).with_tag(tag),
+            NoteRecipient::new(
+                Word::default(),
+                StandardNote::P2ID.script(),
+                NoteStorage::new(vec![]).unwrap(),
+            ),
+        );
+        let record = InputNoteRecord::from(note);
+
+        let summary = note_summary(Some(&record), None);
+
+        assert_eq!(summary.sender, sender.to_string());
+        assert_eq!(summary.tag, tag.to_string());
     }
 }


### PR DESCRIPTION
`notes --show` prints the same value in the `Tag` and `Sender` rows — `note_summary` reads `metadata.tag()` for both.

It read `metadata.sender()` originally. The call was lost in #719, where the `map`/`unwrap_or` pair was rewritten as `map_or`:

```rust
-    let note_sender_str = note_metadata
-        .map(|metadata| metadata.sender().to_string())
-        .unwrap_or("-".to_string());
+    let note_sender_str =
+        note_metadata.map_or("-".to_string(), |metadata| metadata.tag().to_string());
```

Put the `sender()` call back, and added a unit test on `note_summary` with a tag that differs from the sender — it fails without the change.
