### PR TITLE
fix(rpc): verify account_id in VerifyingRpcClient::get_account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * [FIX][rust] `VerifyingRpcClient::sync_transactions` now validates that every returned transaction record's account ID was actually requested, rejecting mismatches with `RpcError::InvalidResponse` ([#2372](https://github.com/0xMiden/rust-sdk/issues/2372)).
 * [FIX][rust] `Client::prove_transaction_with` now checks that the `TransactionProver` returned a proof of the transaction it was asked to prove, rejecting a mismatch with the new `ClientError::MismatchedProvenTransaction` ([#2391](https://github.com/0xMiden/rust-sdk/pull/2391)).
 * [FIX][cli] `miden-client notes --show` now prints the note sender in the `Sender` row; it was printing the note tag there ([#2412](https://github.com/0xMiden/rust-sdk/pull/2412)).
+* [FIX][rust] `VerifyingRpcClient::get_account` now validates that the returned `AccountProof` belongs to the requested account ID, rejecting a mismatch with `RpcError::InvalidResponse` ([#2419](https://github.com/0xMiden/rust-sdk/pull/2419)).
 
 ## 0.16.0-alpha.1 (2026-07-17)
 

--- a/crates/rust-client/src/rpc/verifying_client/mod.rs
+++ b/crates/rust-client/src/rpc/verifying_client/mod.rs
@@ -272,6 +272,13 @@ impl<T: NodeRpcClient> NodeRpcClient for VerifyingRpcClient<T> {
         };
         let (block_num, proof) = self.0.get_account(account_id, request).await?;
         verify_block_num(requested, block_num)?;
+        if proof.account_id() != account_id {
+            return Err(RpcError::InvalidResponse(format!(
+                "node returned proof for account {} but {} was requested",
+                proof.account_id(),
+                account_id,
+            )));
+        }
         Ok((block_num, proof))
     }
 

--- a/crates/rust-client/src/rpc/verifying_client/tests.rs
+++ b/crates/rust-client/src/rpc/verifying_client/tests.rs
@@ -572,6 +572,23 @@ async fn get_account_verifies_block_num_only_for_pinned_requests() {
 }
 
 #[tokio::test]
+async fn get_account_rejects_proof_for_wrong_account_id() {
+    // account_proof() is built for test_account_id() (ACCOUNT_ID_SENDER),
+    // but we request a different account ID -- the verifying client must reject it.
+    let client = VerifyingRpcClient::new(CannedTransport {
+        account: Some((BlockNumber::from(1u32), account_proof())),
+        ..Default::default()
+    });
+    let other = AccountId::try_from(ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE)
+        .expect("test account ID is well formed");
+    let err = client
+        .get_account(other, GetAccountRequest::new())
+        .await
+        .expect_err("proof for a different account must be rejected");
+    assert!(matches!(err, RpcError::InvalidResponse(_)));
+}
+
+#[tokio::test]
 async fn get_note_script_by_root_verifies_script_root() {
     let script = StandardNote::P2ID.script();
     let root = Word::from(script.root());


### PR DESCRIPTION
Closes #2396

## Summary

`VerifyingRpcClient::get_account` validated the block number but never checked whether the returned `AccountProof` actually belongs to the requested `account_id`. A malicious or buggy node could silently return a proof for the wrong account.

Every other method in `VerifyingRpcClient` that takes an identity parameter validates the response matches it (`get_notes_by_id`, `sync_nullifiers`, `sync_transactions`). This PR brings `get_account` in line with those.

## Changes

- **`verifying_client/mod.rs`**: after `verify_block_num`, added an `account_id` equality check that returns `RpcError::InvalidResponse` on mismatch.
- **`verifying_client/tests.rs`**: added `get_account_rejects_proof_for_wrong_account_id` test feeds a proof built for `ACCOUNT_ID_SENDER` while requesting `ACCOUNT_ID_REGULAR_PUBLIC_ACCOUNT_IMMUTABLE_CODE` and asserts the call is rejected.

## Testing

All 12 verifying-client unit tests pass:

```
cargo test -p miden-client --lib rpc::verifying_client
test result: ok. 12 passed; 0 failed
```