### PR TITLE
fix(rpc): return RpcError instead of panicking on oversized chain length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 * [FIX][rust] `Client::prove_transaction_with` now checks that the `TransactionProver` returned a proof of the transaction it was asked to prove, rejecting a mismatch with the new `ClientError::MismatchedProvenTransaction` ([#2391](https://github.com/0xMiden/rust-sdk/pull/2391)).
 * [FIX][cli] `miden-client notes --show` now prints the note sender in the `Sender` row; it was printing the note tag there ([#2412](https://github.com/0xMiden/rust-sdk/pull/2412)).
 * [FIX][rust] `VerifyingRpcClient::get_account` now validates that the returned `AccountProof` belongs to the requested account ID, rejecting a mismatch with `RpcError::InvalidResponse` ([#2419](https://github.com/0xMiden/rust-sdk/pull/2419)).
+* [FIX][rust] `GrpcClient::get_block_header_by_number` no longer panics when the server-reported chain length doesn't fit in `usize`; it returns `RpcError::InvalidResponse` instead. This is reachable on `wasm32`, where `usize` is 32 bits, so a chain length above `u32::MAX` previously crashed any wasm32 client (e.g. the web-sdk) requesting an MMR proof ([#PENDING](https://github.com/0xMiden/rust-sdk/pull/PENDING)).
 
 ## 0.16.0-alpha.1 (2026-07-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@
 * [FIX][rust] `Client::prove_transaction_with` now checks that the `TransactionProver` returned a proof of the transaction it was asked to prove, rejecting a mismatch with the new `ClientError::MismatchedProvenTransaction` ([#2391](https://github.com/0xMiden/rust-sdk/pull/2391)).
 * [FIX][cli] `miden-client notes --show` now prints the note sender in the `Sender` row; it was printing the note tag there ([#2412](https://github.com/0xMiden/rust-sdk/pull/2412)).
 * [FIX][rust] `VerifyingRpcClient::get_account` now validates that the returned `AccountProof` belongs to the requested account ID, rejecting a mismatch with `RpcError::InvalidResponse` ([#2419](https://github.com/0xMiden/rust-sdk/pull/2419)).
-* [FIX][rust] `GrpcClient::get_block_header_by_number` no longer panics when the server-reported chain length doesn't fit in `usize`; it returns `RpcError::InvalidResponse` instead. This is reachable on `wasm32`, where `usize` is 32 bits, so a chain length above `u32::MAX` previously crashed any wasm32 client (e.g. the web-sdk) requesting an MMR proof ([#PENDING](https://github.com/0xMiden/rust-sdk/pull/PENDING)).
+* [FIX][rust] `GrpcClient::get_block_header_by_number` no longer panics when the server-reported chain length doesn't fit in `usize`; it returns `RpcError::InvalidResponse` instead. This is reachable on `wasm32`, where `usize` is 32 bits, so a chain length above `u32::MAX` previously crashed any wasm32 client (e.g. the web-sdk) requesting an MMR proof ([#2424](https://github.com/0xMiden/rust-sdk/pull/2424)).
 
 ## 0.16.0-alpha.1 (2026-07-17)
 

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -517,7 +517,7 @@ impl NodeRpcClient for GrpcClient {
                 .ok_or(RpcError::ExpectedDataMissing("MmrPath".into()))?
                 .try_into()?;
 
-            let forest_size = usize::try_from(forest).expect("u64 should fit in usize");
+            let forest_size = chain_length_to_usize(forest)?;
             let forest = Forest::new(forest_size).map_err(|_| {
                 RpcError::InvalidResponse(format!("invalid forest size: {forest_size}"))
             })?;
@@ -1071,6 +1071,17 @@ impl From<&Status> for GrpcError {
     }
 }
 
+/// Converts a server-reported chain length into a `usize` forest size.
+///
+/// `chain_length` comes directly from the RPC response and is not otherwise
+/// bounded, so this must return an error instead of panicking on platforms
+/// where `usize` is narrower than `u64` (notably `wasm32`, which this crate
+/// targets via the web-sdk).
+fn chain_length_to_usize(chain_length: u64) -> Result<usize, RpcError> {
+    usize::try_from(chain_length)
+        .map_err(|_| RpcError::InvalidResponse(format!("chain length {chain_length} exceeds usize")))
+}
+
 #[cfg(test)]
 mod tests {
     use std::boxed::Box;
@@ -1083,6 +1094,35 @@ mod tests {
     use crate::rpc::{Endpoint, NodeRpcClient, RpcError};
 
     fn assert_send_sync<T: Send + Sync>() {}
+
+    // Before this fix, `get_block_header_by_number` used
+    // `usize::try_from(forest).expect(...)` directly, which panics instead
+    // of returning an `RpcError` whenever a
+    // server-reported chain length doesn't fit in `usize`. That's always
+    // possible on wasm32 (usize is 32 bits there, and this crate explicitly
+    // targets wasm32 for the web-sdk), and would let a malicious or buggy RPC
+    // server crash a wasm32 client just by returning a chain length above
+    // u32::MAX. This test exercises the extracted, panic-free helper directly
+    // rather than standing up a tonic mock server, since no such harness
+    // exists in this crate for GrpcClient's protobuf-conversion methods.
+    // `usize::try_from(u64)` can only fail on targets where `usize` is
+    // narrower than 64 bits (e.g. wasm32, where this crate's web-sdk
+    // consumer actually runs). On 64-bit hosts, which is where this suite
+    // normally runs, every `u64` value fits in `usize`, so this test is
+    // gated to the platform where the bug is actually reachable.
+    #[test]
+    #[cfg(target_pointer_width = "32")]
+    fn chain_length_to_usize_rejects_value_too_large_for_usize() {
+        let oversized = u64::from(u32::MAX) + 1;
+        let result = super::chain_length_to_usize(oversized);
+        assert!(result.is_err(), "expected an error for a chain length exceeding u32::MAX");
+    }
+
+    #[test]
+    fn chain_length_to_usize_accepts_in_range_value() {
+        let result = super::chain_length_to_usize(42);
+        assert_eq!(result.unwrap(), 42usize);
+    }
 
     #[test]
     fn is_send_sync() {


### PR DESCRIPTION
## Problem
`GrpcClient::get_block_header_by_number` (in `crates/rust-client/src/rpc/tonic_client/mod.rs`) converts a server-reported chain length into a forest size like this:

```rust
let forest = response
    .chain_length
    .ok_or(RpcError::ExpectedDataMissing("ChainLength".into()))?;
...
let forest_size = usize::try_from(forest).expect("u64 should fit in usize");
```

`forest`/`chain_length` comes directly from the RPC response - it's not otherwise bounded. `usize::try_from(u64)` only fails when `usize` is narrower than 64 bits, which is exactly the case on `wasm32` (`usize` is 32 bits there). This crate explicitly targets `wasm32` (see the `[target.'cfg(target_arch = "wasm32")'.dependencies]` section of `crates/rust-client/Cargo.toml` and its comments about "wasm32 consumers (the web-sdk's...)"). A chain length above `u32::MAX` (~4.29 billion) would make this `.expect()` panic instead of returning an error, on any wasm32 client - i.e. a malicious or misbehaving RPC server could crash a web-sdk-based client just by returning a large `chain_length` in a `GetBlockHeaderByNumber` response with `include_mmr_proof: true`.

## Why it matters / precedent
The identical conceptual conversion (`forest: u64` -> `usize`) already exists correctly one call away, in `rpc/domain/merkle.rs`:
```rust
let num_leaves = usize::try_from(value.forest).map_err(|_| {
    RpcConversionError::InvalidField("MmrDelta forest value exceeds usize".into())
})?;
```
`tonic_client/mod.rs`'s own next line even follows the correct pattern for a related check (`Forest::new(forest_size).map_err(...)`) - the `.expect()` on the conversion immediately above it is the one place that breaks with that established convention.

## Fix
Extracted the conversion into a small `chain_length_to_usize` helper that returns `Result<usize, RpcError>` via `map_err` instead of panicking, matching the `merkle.rs` precedent, and used it at the one call site.

## Tests
This repo doesn't have a tonic/gRPC mock server harness for `GrpcClient`'s protobuf-conversion methods (the existing `MockRpcApi` mocks the `NodeRpcClient` trait at a higher level, bypassing this exact conversion), so standing one up just for this fix felt disproportionate. Instead I extracted the conversion into a small, pure, directly-testable function and added two unit tests:
- `chain_length_to_usize_accepts_in_range_value` - runs unconditionally.
- `chain_length_to_usize_rejects_value_too_large_for_usize` - gated with `#[cfg(target_pointer_width = "32")]`, since `usize::try_from(u64)` can only fail on a 32-bit target; on the 64-bit hosts this suite normally runs on, every `u64` fits in `usize`, so there's no value that would make the assertion meaningful there. I'm flagging this clearly since it means this specific test won't execute as a real regression check unless CI (or a maintainer) runs it under a 32-bit/wasm32 target - I don't know if this repo's CI does that for unit tests.

I wasn't able to run `cargo test` for this crate in my sandbox - network egress there blocks fetching this workspace's dependencies. I traced the fix and both tests by hand; I'd appreciate CI or a maintainer confirming they compile and pass.

## Scope / trade-off
This only touches the one call site in `tonic_client/mod.rs`; I didn't audit the rest of the crate for other `usize::try_from(u64)` (or similar) conversions on RPC-sourced data beyond the `merkle.rs` one I found already handled correctly. Also flagging: I added a `CHANGELOG.md` entry under `### Fixes` following this repo's existing format, but used a `#PENDING` placeholder for the PR link since I didn't have the PR number yet - happy to update it once the PR number is known, or a maintainer/CI can adjust it.