### PR TITLE
fix(cli): report the actual outcome of `address remove`

### DIFF
--- a/bin/miden-cli/src/commands/address.rs
+++ b/bin/miden-cli/src/commands/address.rs
@@ -166,9 +166,24 @@ async fn remove_address<AUTH>(
     let address = decode_account_address(&address, account_id, &network_id)?;
     let note_tag = address.to_note_tag();
 
-    println!("removing address - Account Id {account_id} - Note tag: {note_tag}");
+    // `Client::remove_address` is a no-op when the address was never tracked, so the
+    // outcome has to be established before removing. Reporting beforehand claimed a
+    // removal that may not have happened.
+    let was_tracked = client
+        .account_reader(account_id)
+        .addresses()
+        .await
+        .map_err(|_| CliError::Input(format!("The account with id `{account_id}` does not exist")))?
+        .contains(&address);
+
+    if !was_tracked {
+        println!("Address wasn't being tracked for Account Id {account_id}");
+        return Ok(());
+    }
 
     client.remove_address(address, account_id).await?;
+
+    println!("Address removed: Account Id {account_id} - Note tag: {note_tag}");
     Ok(())
 }
 

--- a/bin/miden-cli/tests/cli.rs
+++ b/bin/miden-cli/tests/cli.rs
@@ -1266,6 +1266,8 @@ async fn list_addresses_remove() -> Result<()> {
     remove_address_cmd.args(["address", "remove", &basic_account_id, unspecified_wallet_address]);
     let output = remove_address_cmd.current_dir(temp_dir.clone()).output().unwrap();
     assert!(output.status.success());
+    let formatted_output = String::from_utf8(output.stdout).unwrap();
+    assert!(formatted_output.contains("Address removed"));
 
     // List of addresses for created account should now contain one BasicWallet address
     sync_cli(&temp_dir);
@@ -1274,6 +1276,14 @@ async fn list_addresses_remove() -> Result<()> {
     let formatted_output = String::from_utf8(output.stdout).unwrap();
     assert!(formatted_output.contains(&basic_account_id));
     assert_eq!(formatted_output.matches("Unspecified").count(), 0);
+
+    // Removing the same address again removes nothing, so the CLI has to say so
+    // rather than repeat the removal message.
+    let output = remove_address_cmd.current_dir(temp_dir.clone()).output().unwrap();
+    assert!(output.status.success());
+    let formatted_output = String::from_utf8(output.stdout).unwrap();
+    assert!(formatted_output.contains("wasn't being tracked"));
+    assert!(!formatted_output.contains("Address removed"));
 
     Ok(())
 }


### PR DESCRIPTION
## Problem

`address remove` printed its message before doing anything:

```rust
println!("removing address - Account Id {account_id} - Note tag: {note_tag}");

client.remove_address(address, account_id).await?;
```

So a failing removal had already been announced, and — because `Client::remove_address` is documented as a no-op when the address was never tracked — removing an address that does not exist printed a removal message and exited 0 having done nothing:

```
$ miden-client address remove <account-id> <address-never-added>
removing address - Account Id 0x... - Note tag: ...
$ echo $?
0
```

The `add_address` helper directly above it already got this right: it calls first and prints on success.

This is the same class of bug #2416 fixed for tags. That fix could branch on a `bool` because `Client::remove_note_tag` returns one; `Client::remove_address` returns `()`, so the CLI had nothing to branch on.

## Change

`remove_address` now establishes the outcome before removing, and reports it afterwards, wording it the same way `tags.rs` does:

- `Address removed: Account Id {id} - Note tag: {tag}` when it was tracked
- `Address wasn't being tracked for Account Id {id}` when it was not

The premature progress line is gone. No public API changes.

The existing `list_addresses_remove` test now asserts the success message and runs the removal a second time, which fails on `next` and passes here.

## The alternative I did not take

The tidier fix is to give `Client::remove_address` a `bool` return like `remove_note_tag`, so callers other than the CLI can also tell a removal from a no-op — the store already knows how many rows it deleted. I kept this PR to the CLI because it changes no public API; happy to redo it that way if you would prefer, and it would make the two commands properly symmetric.

## Verification — please lean on CI for this one

I could not build the workspace locally. I am on Windows, and `cargo check` fails in a dependency before reaching this crate:

```
error: failed to run custom build command for `miden-node-proto-build v0.16.0-rc.1`
  Error: file '...\miden-node-proto-build-0.16.0-rc.1\proto\remote_prover.proto'
         is not in any include path
```

That looks like a build-script path issue on Windows rather than anything to do with this change, and it is consistent with CI running only on `ubuntu-*` runners — Windows is not a supported build host here, so I am not reporting it as a separate bug.

What I did check: `rustfmt --check` parses both files and reports no diff on the lines this PR touches.

So this has not been compiled and the tests have not been run. The change is small and uses `account_reader(..).addresses()` exactly as `list_account_addresses` does a few lines above, but please let CI be the judge, and tell me if it goes red — I will fix it.

`list_addresses_remove` drives a real client against a node, so the new assertions in particular want a real run. The second removal is the case that fails on `next` today.
