### PR TITLE
fix(cli): report why an imported file is neither a note nor an account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 * [FIX][cli] `miden-client notes --show` now prints the note sender in the `Sender` row; it was printing the note tag there ([#2412](https://github.com/0xMiden/rust-sdk/pull/2412)).
 * [FIX][cli] `miden-client tags --add` and `--remove` now report what actually happened instead of always printing that the tag was added or removed ([#2416](https://github.com/0xMiden/rust-sdk/pull/2416)).
 * [FIX][rust] `VerifyingRpcClient::get_account` now validates that the returned `AccountProof` belongs to the requested account ID, rejecting a mismatch with `RpcError::InvalidResponse` ([#2419](https://github.com/0xMiden/rust-sdk/pull/2419)).
+* [FIX][cli] `miden-client import` now reports that a file is neither a note file nor an account file, naming the file and both parse failures, instead of surfacing only the account attempt as an opaque `io error: invalid data` ([#2428](https://github.com/0xMiden/rust-sdk/pull/2428)).
 
 ## 0.16.0-alpha.1 (2026-07-17)
 

--- a/bin/miden-cli/src/commands/import.rs
+++ b/bin/miden-cli/src/commands/import.rs
@@ -1,12 +1,11 @@
-use std::fs::{self, File};
-use std::io::Read;
+use std::fs;
 use std::path::PathBuf;
 
+use miden_client::Client;
 use miden_client::account::{AccountFile, AccountId};
 use miden_client::keystore::Keystore;
 use miden_client::note::NoteFile;
 use miden_client::utils::Deserializable;
-use miden_client::{Client, ClientError};
 use tracing::info;
 
 use crate::commands::account::{account_code_has_basic_wallet, set_default_account_if_unset};
@@ -32,34 +31,47 @@ impl ImportCmd {
     ) -> Result<(), CliError> {
         validate_paths(&self.filenames)?;
         for filename in &self.filenames {
-            let note_file = read_note_file(filename.clone());
+            // Read once and try both parsers on the same bytes: the file is either a note file or
+            // an account file, and both errors are needed to say which it failed to be.
+            let contents = fs::read(filename)?;
 
-            if let Ok(note_file) = note_file {
-                match client.import_notes(&[note_file]).await?.first() {
-                    Some(commitment) => println!(
-                        "Successfully imported note with details commitment {}",
-                        commitment.to_hex()
-                    ),
-                    None => println!("Note was already up to date; nothing to import."),
-                }
-            } else {
-                info!(
-                    "Attempting to import account data from {}...",
-                    fs::canonicalize(filename)?.as_path().display()
-                );
-                let account_file = AccountFile::read(filename)?;
-                let account_id =
-                    import_account(&mut client, &keystore, account_file, self.overwrite).await?;
+            let note_error = match NoteFile::read_from_bytes(&contents) {
+                Ok(note_file) => {
+                    match client.import_notes(&[note_file]).await?.first() {
+                        Some(commitment) => println!(
+                            "Successfully imported note with details commitment {}",
+                            commitment.to_hex()
+                        ),
+                        None => println!("Note was already up to date; nothing to import."),
+                    }
+                    continue;
+                },
+                Err(err) => err,
+            };
 
-                println!("Successfully imported account {account_id}");
+            info!(
+                "Attempting to import account data from {}...",
+                fs::canonicalize(filename)?.as_path().display()
+            );
+            let account_file =
+                AccountFile::read_from_bytes(&contents).map_err(|account_error| {
+                    CliError::Import(format!(
+                        "`{}` is neither a note file ({note_error}) nor an account file \
+                         ({account_error})",
+                        filename.display()
+                    ))
+                })?;
+            let account_id =
+                import_account(&mut client, &keystore, account_file, self.overwrite).await?;
 
-                // Only basic wallets are eligible to become the default account; faucets and
-                // other account kinds are skipped.
-                if let Some(code) = client.get_account_code(account_id).await?
-                    && account_code_has_basic_wallet(account_id, &code)
-                {
-                    set_default_account_if_unset(&mut client, account_id).await?;
-                }
+            println!("Successfully imported account {account_id}");
+
+            // Only basic wallets are eligible to become the default account; faucets and
+            // other account kinds are skipped.
+            if let Some(code) = client.get_account_code(account_id).await?
+                && account_code_has_basic_wallet(account_id, &code)
+            {
+                set_default_account_if_unset(&mut client, account_id).await?;
             }
         }
         Ok(())
@@ -94,22 +106,10 @@ async fn import_account<AUTH>(
     Ok(account_id)
 }
 
-// IMPORT NOTE
-// ================================================================================================
-
-fn read_note_file(filename: PathBuf) -> Result<NoteFile, CliError> {
-    let mut contents = vec![];
-    let mut _file = File::open(filename).and_then(|mut f| f.read_to_end(&mut contents))?;
-
-    NoteFile::read_from_bytes(&contents)
-        .map_err(|err| ClientError::DataDeserializationError(err).into())
-}
-
 // HELPERS
 // ================================================================================================
 
-/// Checks that all files exist, otherwise returns an error. It also ensures that all files have a
-/// specific extension.
+/// Checks that all the given paths exist, otherwise returns an error.
 fn validate_paths(paths: &[PathBuf]) -> Result<(), CliError> {
     let invalid_path = paths.iter().find(|path| !path.exists());
 

--- a/bin/miden-cli/tests/cli.rs
+++ b/bin/miden-cli/tests/cli.rs
@@ -678,6 +678,28 @@ fn account_inspect_flags_require_inspect() {
 // IMPORT TESTS
 // ================================================================================================
 
+/// A file that parses as neither kind should say so, naming the file and both reasons, rather
+/// than surfacing the account attempt alone as an opaque I/O failure.
+#[test]
+fn import_reports_why_a_file_is_neither_a_note_nor_an_account() {
+    let temp_dir = temp_dir().join(format!("cli-test-{}", rand::rng().random::<u64>()));
+    std::fs::create_dir_all(&temp_dir).unwrap();
+
+    let mut init_cmd = cargo_bin_cmd!("miden-client");
+    init_cmd.args(["init", "--local"]);
+    init_cmd.current_dir(&temp_dir).assert().success();
+
+    std::fs::write(temp_dir.join("not-a-note.mno"), b"definitely not a miden file").unwrap();
+
+    let mut import_cmd = cargo_bin_cmd!("miden-client");
+    import_cmd.args(["import", "not-a-note.mno"]);
+    import_cmd
+        .current_dir(&temp_dir)
+        .assert()
+        .failure()
+        .stderr(contains("not-a-note.mno").and(contains("neither a note file")));
+}
+
 // Only one faucet is being created on the genesis block
 const GENESIS_ACCOUNTS_FILENAMES: [&str; 1] = ["account.mac"];
 


### PR DESCRIPTION
### Problem

`import` tries a file as a note first and falls back to an account. Neither failure survives:

- the note error is dropped by `if let Ok(note_file) = note_file { .. } else { .. }`
- `AccountFile::read` maps any `DeserializationError` to `io::ErrorKind::InvalidData`, so the account error is dropped upstream too

What reaches the user is `CliError::IO`:

```
Error: cli::io_error

  × io error
  ╰─▶ invalid data
```

That is the same output for a corrupt note file, an empty file, and a file that was never a Miden artifact. The path is not named either, which matters because `import` takes a list of files. It is also not an I/O failure - the read succeeded, the bytes did not parse.

### Change

Read the file once and try both parsers on the same bytes, keeping both errors and reporting them through the existing `CliError::Import` variant:

```
Error: cli::import_error

  × import error: `broken.mno` is neither a note file (invalid value: invalid
  │ note file marker: this) nor an account file (invalid value: invalid
  │ account file marker: this)
  help: Check the file name.
```

A genuine I/O failure now surfaces as one instead of being retried as an account, and `validate_paths` still reports a missing path as before.

This also drops a second read of the file: `read_note_file` read it, then `AccountFile::read` opened and read it again.

`read_note_file` is now unused and removed. The `validate_paths` doc comment claimed it "ensures that all files have a specific extension"; it only checks existence, so that sentence is gone.

### Test plan

```
cargo test -p miden-client-cli --test integration import_reports_why
```

`import_reports_why_a_file_is_neither_a_note_nor_an_account` writes a file that is neither, and asserts the error names it along with both reasons. It fails on `next` with the `invalid data` output above.

The node-free CLI tests (`init_*`, `account_inspect_*`, `silent_*`, `miden_directory_structure_creation`) still pass; the export/import round-trip tests need a node, so I am relying on CI for those.
