### PR TITLE
fix(cli): report the actual outcome of `account --default`

### DIFF
--- a/bin/miden-cli/src/commands/account.rs
+++ b/bin/miden-cli/src/commands/account.rs
@@ -125,8 +125,18 @@ impl AccountCmd {
                         println!("Current default account ID: {default_account}");
                     },
                     Some(id) if id == "none" => {
-                        client.remove_setting(DEFAULT_ACCOUNT_ID_KEY.to_string()).await?;
-                        println!("Removing default account...");
+                        // `remove_setting` succeeds whether or not a default was set, so the
+                        // previous value has to be read first to report which of the two happened.
+                        let previous: Option<AccountId> =
+                            client.get_setting(DEFAULT_ACCOUNT_ID_KEY.to_string()).await?;
+
+                        match previous {
+                            Some(previous) => {
+                                client.remove_setting(DEFAULT_ACCOUNT_ID_KEY.to_string()).await?;
+                                println!("Default account removed (was {previous})");
+                            },
+                            None => println!("No default account was set"),
+                        }
                     },
                     Some(id) => {
                         let account_id: AccountId = parse_account_id(&client, id).await?;
@@ -137,7 +147,10 @@ impl AccountCmd {
                         client
                             .set_setting(DEFAULT_ACCOUNT_ID_KEY.to_string(), account.id())
                             .await?;
-                        println!("Setting default account to {id}...");
+                        // Report the ID that was stored, not the argument: `parse_account_id`
+                        // also accepts an ID prefix or a bech32 address, so echoing the input
+                        // hides which account the setting now points at.
+                        println!("Default account set to {}", account.id());
                     },
                 }
             },


### PR DESCRIPTION
Same class as #2427 and #2416: the command reports something other than what it did.

## Clearing reports a removal that may not have happened

```rust
Some(id) if id == "none" => {
    client.remove_setting(DEFAULT_ACCOUNT_ID_KEY.to_string()).await?;
    println!("Removing default account...");
},
```

`Client::remove_setting` returns `Result<(), _>` and succeeds whether or not the key was there, so with no default set:

```
$ miden-client account --default none
Removing default account...
$ echo $?
0
```

Nothing was cleared. The command now reads the previous value first and reports which of the two happened, naming the account it cleared:

```
Default account removed (was 0x…)
No default account was set
```

## Setting echoes the argument, not what was stored

```rust
let account_id: AccountId = parse_account_id(&client, id).await?;
let (account, _) = client.account_reader(account_id).header().await?;
client.set_setting(DEFAULT_ACCOUNT_ID_KEY.to_string(), account.id()).await?;
println!("Setting default account to {id}...");
```

The setting is written from the resolved `account.id()`, but the message prints `id` — the raw argument. [`parse_account_id`](https://github.com/0xMiden/rust-sdk/blob/next/bin/miden-cli/src/utils.rs#L57) accepts three forms:

- a full hex ID
- an **ID prefix**, resolved against the store
- a **bech32 address**

So `account --default 0x1234` confirms `0x1234` while storing the full ID, and a bech32 argument is confirmed in a form the setting does not hold. In both cases the output does not tell you which account the default now points at.

The read branch directly above already prints the canonical `AccountId`. The write branch now matches it.

## Wording

Both messages used the progressive tense with a trailing `...`, but the work is finished by the time they print. Changed to the completed form #2416 settled on for `tags`.

## Verification

`rustfmt --check` parses the file and reports no diff on the lines this PR touches. The only diff it reports is the pre-existing import block, which stable rustfmt reformats because the repo's `rustfmt.toml` uses nightly-only `imports_granularity` / `group_imports`.

As with #2427, I could not build the workspace: on Windows `cargo check` fails in `miden-node-proto-build` before reaching this crate, which is consistent with CI running only on `ubuntu-*`. So this is not compiled and the CLI tests have not been run — please let CI be the judge, and tell me if it goes red.

`account --default` has no CLI test coverage today. I left this PR to the source change rather than adding tests I cannot run, but happy to add them if you would like.
