### PR TITLE
fix(note): check spent nullifiers during transport import

### DIFF
--- a/crates/rust-client/src/note/import.rs
+++ b/crates/rust-client/src/note/import.rs
@@ -14,13 +14,8 @@ use alloc::vec::Vec;
 
 use miden_protocol::block::BlockNumber;
 use miden_protocol::note::{
-    Note,
-    NoteAttachments,
-    NoteDetails,
-    NoteDetailsCommitment,
-    NoteId,
-    NoteInclusionProof,
-    NoteTag,
+    Note, NoteAttachments, NoteDetails, NoteDetailsCommitment, NoteId, NoteInclusionProof, NoteTag,
+    Nullifier,
 };
 use miden_standards::note::NoteFile;
 use miden_tx::auth::TransactionAuthenticator;
@@ -355,6 +350,30 @@ where
         let mut committed_notes_data =
             self.sync_expected_notes(lowest_request_block, note_requests).await?;
 
+        let details_by_commitment: BTreeMap<NoteDetailsCommitment, NoteDetails> = requested_notes
+            .iter()
+            .map(|(_, details, _, _)| (details.commitment(), details.clone()))
+            .collect();
+        let mut nullifier_requests = BTreeSet::new();
+        let mut lowest_nullifier_block: BlockNumber = u32::MAX.into();
+        for (commitment, synced_note) in &committed_notes_data {
+            let Some(details) = details_by_commitment.get(commitment) else {
+                continue;
+            };
+            nullifier_requests.insert(Nullifier::from_details_and_metadata(
+                details,
+                synced_note.committed.metadata(),
+            ));
+            lowest_nullifier_block = lowest_nullifier_block.min(synced_note.committed.block_num());
+        }
+        let nullifier_commit_heights = if nullifier_requests.is_empty() {
+            BTreeMap::new()
+        } else {
+            self.rpc_api
+                .get_nullifier_commit_heights(nullifier_requests, lowest_nullifier_block)
+                .await?
+        };
+
         let mut note_records = vec![];
         let mut partial_mmr = self.get_current_partial_mmr().await?;
 
@@ -394,6 +413,14 @@ where
 
             // `block_header_received` transitions the record's state, so it must always run.
             note_changed |= note_record.block_header_received(&block_header)?;
+
+            let nullifier = Nullifier::from_details_and_metadata(note_record.details(), &metadata);
+            if let Some(nullifier_block_height) =
+                nullifier_commit_heights.get(&nullifier).and_then(|height| *height)
+            {
+                note_changed |=
+                    note_record.consumed_externally(nullifier, nullifier_block_height, None)?;
+            }
 
             // Once committed, the note no longer needs its expected-note tag.
             if note_changed {

--- a/crates/rust-client/src/note/import.rs
+++ b/crates/rust-client/src/note/import.rs
@@ -14,7 +14,13 @@ use alloc::vec::Vec;
 
 use miden_protocol::block::BlockNumber;
 use miden_protocol::note::{
-    Note, NoteAttachments, NoteDetails, NoteDetailsCommitment, NoteId, NoteInclusionProof, NoteTag,
+    Note,
+    NoteAttachments,
+    NoteDetails,
+    NoteDetailsCommitment,
+    NoteId,
+    NoteInclusionProof,
+    NoteTag,
     Nullifier,
 };
 use miden_standards::note::NoteFile;
@@ -350,9 +356,16 @@ where
         let mut committed_notes_data =
             self.sync_expected_notes(lowest_request_block, note_requests).await?;
 
+        // Spends that happened at or below the current sync height are invisible to the forward
+        // nullifier sync, which only scans from `sync_height + 1` onwards and never rewinds. Look
+        // those up here, from the earliest imported note's inclusion block, so a note that was
+        // already consumed before this client learned about it is not imported as consumable.
+        // Spends above the sync height are left to the next sync, which also attributes the
+        // consuming account when it is tracked locally.
+        let sync_height = self.get_sync_height().await?;
         let details_by_commitment: BTreeMap<NoteDetailsCommitment, NoteDetails> = requested_notes
             .iter()
-            .map(|(_, details, _, _)| (details.commitment(), details.clone()))
+            .map(|(_, details, ..)| (details.commitment(), details.clone()))
             .collect();
         let mut nullifier_requests = BTreeSet::new();
         let mut lowest_nullifier_block: BlockNumber = u32::MAX.into();
@@ -417,6 +430,7 @@ where
             let nullifier = Nullifier::from_details_and_metadata(note_record.details(), &metadata);
             if let Some(nullifier_block_height) =
                 nullifier_commit_heights.get(&nullifier).and_then(|height| *height)
+                && nullifier_block_height <= sync_height
             {
                 note_changed |=
                     note_record.consumed_externally(nullifier, nullifier_block_height, None)?;

--- a/crates/testing/miden-client-tests/src/tests/transport.rs
+++ b/crates/testing/miden-client-tests/src/tests/transport.rs
@@ -6,20 +6,30 @@ use miden_client::address::{Address, AddressInterface, RoutingParameters};
 use miden_client::builder::ClientBuilder;
 use miden_client::keystore::FilesystemKeyStore;
 use miden_client::note::{
-    NetworkAccountTarget, Note, NoteDetails, NoteExecutionHint, NoteTag, NoteType,
+    NetworkAccountTarget,
+    Note,
+    NoteDetails,
+    NoteExecutionHint,
+    NoteTag,
+    NoteType,
 };
 use miden_client::note_transport::NoteTransportClient;
 use miden_client::store::{InputNoteState, NoteFilter};
 use miden_client::testing::common::create_test_store_path;
 use miden_client::testing::mock::{MockClient, MockRpcApi};
 use miden_client::testing::note_transport::{
-    FaultyNoteTransportApi, MockNoteTransportApi, MockNoteTransportNode,
+    FaultyNoteTransportApi,
+    MockNoteTransportApi,
+    MockNoteTransportNode,
 };
 use miden_client::utils::RwLock;
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
 use miden_protocol::Felt;
 use miden_protocol::account::{
-    AccountId, AccountIdVersion, AccountType as ProtocolAccountType, AssetCallbackFlag,
+    AccountId,
+    AccountIdVersion,
+    AccountType as ProtocolAccountType,
+    AssetCallbackFlag,
 };
 use miden_protocol::asset::{Asset, FungibleAsset};
 use miden_protocol::block::BlockNumber;
@@ -33,7 +43,9 @@ use miden_testing::{Auth, MockChainBuilder, MockTransactionInput};
 use rand::RngExt;
 
 use crate::tests::{
-    create_test_client_builder, insert_new_wallet, seed_mock_transaction_encryption_key,
+    create_test_client_builder,
+    insert_new_wallet,
+    seed_mock_transaction_encryption_key,
 };
 
 #[tokio::test]

--- a/crates/testing/miden-client-tests/src/tests/transport.rs
+++ b/crates/testing/miden-client-tests/src/tests/transport.rs
@@ -6,30 +6,20 @@ use miden_client::address::{Address, AddressInterface, RoutingParameters};
 use miden_client::builder::ClientBuilder;
 use miden_client::keystore::FilesystemKeyStore;
 use miden_client::note::{
-    NetworkAccountTarget,
-    Note,
-    NoteDetails,
-    NoteExecutionHint,
-    NoteTag,
-    NoteType,
+    NetworkAccountTarget, Note, NoteDetails, NoteExecutionHint, NoteTag, NoteType,
 };
 use miden_client::note_transport::NoteTransportClient;
-use miden_client::store::NoteFilter;
+use miden_client::store::{InputNoteState, NoteFilter};
 use miden_client::testing::common::create_test_store_path;
 use miden_client::testing::mock::{MockClient, MockRpcApi};
 use miden_client::testing::note_transport::{
-    FaultyNoteTransportApi,
-    MockNoteTransportApi,
-    MockNoteTransportNode,
+    FaultyNoteTransportApi, MockNoteTransportApi, MockNoteTransportNode,
 };
 use miden_client::utils::RwLock;
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
 use miden_protocol::Felt;
 use miden_protocol::account::{
-    AccountId,
-    AccountIdVersion,
-    AccountType as ProtocolAccountType,
-    AssetCallbackFlag,
+    AccountId, AccountIdVersion, AccountType as ProtocolAccountType, AssetCallbackFlag,
 };
 use miden_protocol::asset::{Asset, FungibleAsset};
 use miden_protocol::block::BlockNumber;
@@ -43,9 +33,7 @@ use miden_testing::{Auth, MockChainBuilder, MockTransactionInput};
 use rand::RngExt;
 
 use crate::tests::{
-    create_test_client_builder,
-    insert_new_wallet,
-    seed_mock_transaction_encryption_key,
+    create_test_client_builder, insert_new_wallet, seed_mock_transaction_encryption_key,
 };
 
 #[tokio::test]
@@ -180,7 +168,7 @@ async fn unavailable_attachments_do_not_fail_sync() {
     // path: the note advertises attachment content the node cannot serve, and the sync succeeds
     // by skipping the note.
     let (mut client, private_note, mock_transport_node) =
-        committed_private_note_recipient(0, true).await;
+        committed_private_note_recipient(0, true, false).await;
     assert!(client.get_input_notes(NoteFilter::All).await.unwrap().is_empty());
 
     // Receiving the same note over the NTL imports it, but it stays expected rather than being
@@ -812,7 +800,7 @@ async fn fetch_private_notes_uses_sender_provided_after_block_num() {
     // Commit the note at block 1, then advance far enough that the 20-block fallback window
     // (sync_height - 20) starts well above block 1 and would miss it.
     let (mut client, private_note, mock_transport_node) =
-        committed_private_note_recipient(30, false).await;
+        committed_private_note_recipient(30, false, false).await;
 
     let sync_height = client.get_sync_height().await.unwrap();
     assert!(
@@ -844,7 +832,7 @@ async fn fetch_private_notes_uses_sender_provided_after_block_num() {
 #[tokio::test]
 async fn fetch_private_notes_without_floor_falls_back_to_lookback_window() {
     let (mut client, private_note, mock_transport_node) =
-        committed_private_note_recipient(30, false).await;
+        committed_private_note_recipient(30, false, false).await;
 
     // Deliver the note WITHOUT a floor: the recipient must rely on the lookback heuristic.
     let details_bytes = NoteDetails::from(private_note.clone()).to_bytes();
@@ -865,6 +853,30 @@ async fn fetch_private_notes_without_floor_falls_back_to_lookback_window() {
     assert!(
         !committed_notes.iter().any(|n| n.id() == Some(private_note.id())),
         "without a floor the lookback window misses a note committed before sync_height - 20"
+    );
+}
+
+/// A note already consumed before first delivery through NTL must not remain consumable.
+#[tokio::test]
+async fn fetch_private_notes_marks_historically_consumed_note() {
+    let (mut client, private_note, mock_transport_node) =
+        committed_private_note_recipient(0, false, true).await;
+
+    let details_bytes = NoteDetails::from(private_note.clone()).to_bytes();
+    mock_transport_node.write().add_note(*private_note.header(), details_bytes);
+
+    client.sync_state().await.unwrap();
+
+    let notes = client
+        .get_input_notes(NoteFilter::DetailsCommitments(vec![private_note.details_commitment()]))
+        .await
+        .unwrap();
+    assert_eq!(notes.len(), 1, "the NTL-delivered note should be imported");
+    assert!(notes[0].is_consumed(), "historically spent note must not remain consumable");
+    assert!(
+        matches!(notes[0].state(), InputNoteState::ConsumedExternal(..)),
+        "expected ConsumedExternal, got {}",
+        notes[0].state()
     );
 }
 
@@ -947,6 +959,7 @@ fn private_note_with_tag(account: AccountId, tag: NoteTag, seed: u64) -> Note {
 async fn committed_private_note_recipient(
     blocks_past_commitment: u32,
     with_unserved_attachment: bool,
+    consume_before_sync: bool,
 ) -> (MockClient<FilesystemKeyStore>, Note, Arc<RwLock<MockNoteTransportNode>>) {
     let mut mock_chain_builder = MockChainBuilder::new();
     let mock_account = mock_chain_builder
@@ -984,6 +997,21 @@ async fn committed_private_note_recipient(
     .unwrap();
     mock_chain.add_pending_executed_transaction(&tx).unwrap();
     mock_chain.prove_next_block().unwrap();
+
+    if consume_before_sync {
+        let consume_tx = Box::pin(
+            mock_chain
+                .build_transaction(MockTransactionInput::AccountId(mock_account.id()))
+                .unauthenticated_input_note(private_note.clone())
+                .build()
+                .unwrap()
+                .execute(),
+        )
+        .await
+        .unwrap();
+        mock_chain.add_pending_executed_transaction(&consume_tx).unwrap();
+        mock_chain.prove_next_block().unwrap();
+    }
 
     // Advance the chain past the note's commitment block.
     for _ in 0..blocks_past_commitment {


### PR DESCRIPTION
## What does this PR do?

Marks note-transport imports as `ConsumedExternal` when their nullifiers were already committed on-chain before the client imported them.

## Related Issue

Fixes #2422

## Root Cause

Notes delivered through the note transport enter `import_note_records_by_details` via `NoteFile::ExpectedNote`. That path discovers and authenticates the note commitment, but it did not query historical nullifier state. The existing `get_nullifier_commit_heights` check was only used by the inclusion-proof import path.

When a restored client has already synced past a note's spend block, forward nullifier sync starts after the checkpoint and can never observe that historical spend. The transport-imported record therefore remained `Committed` and was returned as consumable even though the node would reject it as already spent.

## Changes Made

- Batch nullifier lookups for notes found committed during details import.
- Start the lookup at the earliest imported note inclusion block so historical spends are included.
- Reuse the existing `InputNoteRecord::consumed_externally` state transition.
- Add a transport regression test covering a private note consumed on-chain before its first NTL delivery.
- Leave notes that are still only `Expected` unchanged and avoid an RPC call when no committed details are found.

## How to Test

Command attempted:

```text
cargo test --locked -p miden-client-unit-tests fetch_private_notes_marks_historically_consumed_note -- --nocapture
```

The test was blocked before compilation by the Windows environment while building the existing `miden-node-proto-build v0.16.0-rc.1` dependency:

```text
file '...miden-node-proto-build-0.16.0-rc.1\protoemote_prover.proto' is not in any include path
```

`cargo check --locked -p miden-client --features testing` hit the same pre-test build-script failure. WSL Ubuntu-22.04 is installed but has no Cargo toolchain. No test assertion failure was observed.

## Scope

- No new dependencies.
- `Cargo.lock` unchanged.
- Focused to note import behavior and its transport integration test.