### PR TITLE
feat: small CLI improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [BREAKING][behavior][store] The SQLite base schema now declares an index on `input_notes(script_root)`. This changes the schema fingerprint, so opening a database created before this change fails with `SchemaDrift` and existing stores must be recreated ([#2335](https://github.com/0xMiden/rust-sdk/pull/2335)).
 * [BREAKING][removal][rust] `miden_client::agglayer::create_bridge_account` and `miden_client::agglayer::create_agglayer_faucet` are removed. Build the accounts with `AggLayerBridge::account_builder` and `AggLayerFaucet::account_builder`, which return an `AccountBuilder` and take the account's `FeePolicyManager` explicitly; its active policy must be a `BasicConstantFeePolicy` scheduling every root in the account's `allowed_notes()`. The faucet builder additionally takes the initial token supply and the account seeding its `ADMIN` role.
 * [BREAKING][rust] `Client::add_note_tag` and `Client::remove_note_tag` return `bool` instead of `()`, reporting whether the tag was actually added or removed. Both used to swallow that outcome and only log it ([#2416](https://github.com/0xMiden/rust-sdk/pull/2416)).
+* [BREAKING][rust] `Client::remove_setting` and `Store::remove_setting` return `bool` instead of `()`, reporting whether the key had a value set.
 
 ### Enhancements
 
@@ -60,6 +61,7 @@
 * [FIX][rust] `Client::prove_transaction_with` now checks that the `TransactionProver` returned a proof of the transaction it was asked to prove, rejecting a mismatch with the new `ClientError::MismatchedProvenTransaction` ([#2391](https://github.com/0xMiden/rust-sdk/pull/2391)).
 * [FIX][cli] `miden-client notes --show` now prints the note sender in the `Sender` row; it was printing the note tag there ([#2412](https://github.com/0xMiden/rust-sdk/pull/2412)).
 * [FIX][cli] `miden-client tags --add` and `--remove` now report what actually happened instead of always printing that the tag was added or removed ([#2416](https://github.com/0xMiden/rust-sdk/pull/2416)).
+* [FIX][cli] `miden-client account --default none` now reports whether a default account was actually removed instead of always printing that it was. Removing an absent setting also no longer panics in debug builds.
 * [FIX][rust] `VerifyingRpcClient::get_account` now validates that the returned `AccountProof` belongs to the requested account ID, rejecting a mismatch with `RpcError::InvalidResponse` ([#2419](https://github.com/0xMiden/rust-sdk/pull/2419)).
 
 ## 0.16.0-alpha.1 (2026-07-17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [BREAKING][removal][rust] `miden_client::agglayer::create_bridge_account` and `miden_client::agglayer::create_agglayer_faucet` are removed. Build the accounts with `AggLayerBridge::account_builder` and `AggLayerFaucet::account_builder`, which return an `AccountBuilder` and take the account's `FeePolicyManager` explicitly; its active policy must be a `BasicConstantFeePolicy` scheduling every root in the account's `allowed_notes()`. The faucet builder additionally takes the initial token supply and the account seeding its `ADMIN` role.
 * [BREAKING][rust] `Client::add_note_tag` and `Client::remove_note_tag` return `bool` instead of `()`, reporting whether the tag was actually added or removed. Both used to swallow that outcome and only log it ([#2416](https://github.com/0xMiden/rust-sdk/pull/2416)).
 * [BREAKING][rust] `Client::remove_setting` and `Store::remove_setting` return `bool` instead of `()`, reporting whether the key had a value set.
+* [BREAKING][rust] `Client::remove_address` and `Store::remove_address` return `bool` instead of `()`, reporting whether the address was tracked. When it wasn't, `Client::remove_address` now leaves the derived note tag in place instead of running its cleanup.
 
 ### Enhancements
 
@@ -62,6 +63,7 @@
 * [FIX][cli] `miden-client notes --show` now prints the note sender in the `Sender` row; it was printing the note tag there ([#2412](https://github.com/0xMiden/rust-sdk/pull/2412)).
 * [FIX][cli] `miden-client tags --add` and `--remove` now report what actually happened instead of always printing that the tag was added or removed ([#2416](https://github.com/0xMiden/rust-sdk/pull/2416)).
 * [FIX][cli] `miden-client account --default none` now reports whether a default account was actually removed instead of always printing that it was. Removing an absent setting also no longer panics in debug builds.
+* [FIX][cli] `miden-client address remove` now reports whether the address was actually removed instead of always printing that it was being removed.
 * [FIX][rust] `VerifyingRpcClient::get_account` now validates that the returned `AccountProof` belongs to the requested account ID, rejecting a mismatch with `RpcError::InvalidResponse` ([#2419](https://github.com/0xMiden/rust-sdk/pull/2419)).
 
 ## 0.16.0-alpha.1 (2026-07-17)

--- a/bin/miden-cli/src/commands/account.rs
+++ b/bin/miden-cli/src/commands/account.rs
@@ -125,8 +125,14 @@ impl AccountCmd {
                         println!("Current default account ID: {default_account}");
                     },
                     Some(id) if id == "none" => {
-                        client.remove_setting(DEFAULT_ACCOUNT_ID_KEY.to_string()).await?;
-                        println!("Removing default account...");
+                        let removed =
+                            client.remove_setting(DEFAULT_ACCOUNT_ID_KEY.to_string()).await?;
+
+                        if removed {
+                            println!("Default account removed");
+                        } else {
+                            println!("No default account was set");
+                        }
                     },
                     Some(id) => {
                         let account_id: AccountId = parse_account_id(&client, id).await?;

--- a/bin/miden-cli/src/commands/address.rs
+++ b/bin/miden-cli/src/commands/address.rs
@@ -166,9 +166,12 @@ async fn remove_address<AUTH>(
     let address = decode_account_address(&address, account_id, &network_id)?;
     let note_tag = address.to_note_tag();
 
-    println!("removing address - Account Id {account_id} - Note tag: {note_tag}");
+    if client.remove_address(address, account_id).await? {
+        println!("Address removed - Account Id {account_id} - Note tag: {note_tag}");
+    } else {
+        println!("No address was tracked for Account Id {account_id}");
+    }
 
-    client.remove_address(address, account_id).await?;
     Ok(())
 }
 

--- a/bin/miden-cli/src/commands/import.rs
+++ b/bin/miden-cli/src/commands/import.rs
@@ -1,12 +1,11 @@
-use std::fs::{self, File};
-use std::io::Read;
+use std::fs;
 use std::path::PathBuf;
 
+use miden_client::Client;
 use miden_client::account::{AccountFile, AccountId};
 use miden_client::keystore::Keystore;
 use miden_client::note::NoteFile;
 use miden_client::utils::Deserializable;
-use miden_client::{Client, ClientError};
 use tracing::info;
 
 use crate::commands::account::{account_code_has_basic_wallet, set_default_account_if_unset};
@@ -32,9 +31,9 @@ impl ImportCmd {
     ) -> Result<(), CliError> {
         validate_paths(&self.filenames)?;
         for filename in &self.filenames {
-            let note_file = read_note_file(filename.clone());
+            let contents = fs::read(filename)?;
 
-            if let Ok(note_file) = note_file {
+            if let Ok(note_file) = NoteFile::read_from_bytes(&contents) {
                 match client.import_notes(&[note_file]).await?.first() {
                     Some(commitment) => println!(
                         "Successfully imported note with details commitment {}",
@@ -47,7 +46,12 @@ impl ImportCmd {
                     "Attempting to import account data from {}...",
                     fs::canonicalize(filename)?.as_path().display()
                 );
-                let account_file = AccountFile::read(filename)?;
+                let Ok(account_file) = AccountFile::read_from_bytes(&contents) else {
+                    return Err(CliError::Import(format!(
+                        "failed to read `{}` as a note or as an account",
+                        filename.to_string_lossy()
+                    )));
+                };
                 let account_id =
                     import_account(&mut client, &keystore, account_file, self.overwrite).await?;
 
@@ -92,17 +96,6 @@ async fn import_account<AUTH>(
     client.add_account(&account, overwrite).await?;
 
     Ok(account_id)
-}
-
-// IMPORT NOTE
-// ================================================================================================
-
-fn read_note_file(filename: PathBuf) -> Result<NoteFile, CliError> {
-    let mut contents = vec![];
-    let mut _file = File::open(filename).and_then(|mut f| f.read_to_end(&mut contents))?;
-
-    NoteFile::read_from_bytes(&contents)
-        .map_err(|err| ClientError::DataDeserializationError(err).into())
 }
 
 // HELPERS

--- a/crates/rust-client/src/account/mod.rs
+++ b/crates/rust-client/src/account/mod.rs
@@ -494,21 +494,25 @@ impl<AUTH> Client<AUTH> {
     }
 
     /// Removes an [`Address`] from the associated [`AccountId`], alongside its derived [`NoteTag`].
-    /// If no address was tracked for the given account, this is a no-op.
+    ///
+    /// Returns `true` if the address was tracked. If it wasn't, this is a no-op: the derived tag is
+    /// left in place, since it may have been registered by something other than this address.
     pub async fn remove_address(
         &mut self,
         address: Address,
         account_id: AccountId,
-    ) -> Result<(), ClientError> {
+    ) -> Result<bool, ClientError> {
         let derived_note_tag = address.to_note_tag();
         let note_tag_record = NoteTagRecord::with_account_source(derived_note_tag, account_id);
-        self.store.remove_address(address).await?;
+        if !self.store.remove_address(address).await? {
+            return Ok(false);
+        }
         // Remove the note tag if no other address are associated with it.
         let addresses = self.store.get_addresses_by_account_id(account_id).await?;
         if addresses.iter().all(|address| address.to_note_tag() != derived_note_tag) {
             self.store.remove_note_tag(note_tag_record).await?;
         }
-        Ok(())
+        Ok(true)
     }
 
     // ACCOUNT DATA RETRIEVAL

--- a/crates/rust-client/src/note_transport/mod.rs
+++ b/crates/rust-client/src/note_transport/mod.rs
@@ -249,7 +249,8 @@ impl<AUTH> Client<AUTH> {
     async fn save_relay_outbox(&self, entries: Vec<NoteInfo>) -> Result<(), ClientError> {
         let key = String::from(NOTE_TRANSPORT_OUTBOX_KEY);
         if entries.is_empty() {
-            return self.store.remove_setting(key).await.map_err(ClientError::StoreError);
+            self.store.remove_setting(key).await.map_err(ClientError::StoreError)?;
+            return Ok(());
         }
         let bytes = entries.to_bytes();
         self.store.set_setting(key, bytes).await.map_err(ClientError::StoreError)
@@ -309,7 +310,8 @@ impl<AUTH> Client<AUTH> {
     async fn save_covered_tags(&self, tags: &BTreeSet<NoteTag>) -> Result<(), ClientError> {
         let key = String::from(NOTE_TRANSPORT_COVERED_TAGS_KEY);
         if tags.is_empty() {
-            return self.store.remove_setting(key).await.map_err(ClientError::StoreError);
+            self.store.remove_setting(key).await.map_err(ClientError::StoreError)?;
+            return Ok(());
         }
         self.store
             .set_setting(key, tags.to_bytes())

--- a/crates/rust-client/src/settings/mod.rs
+++ b/crates/rust-client/src/settings/mod.rs
@@ -43,8 +43,8 @@ impl<AUTH> Client<AUTH> {
             .map_err(Into::into)
     }
 
-    /// Deletes the setting value from the store.
-    pub async fn remove_setting(&mut self, key: String) -> Result<(), ClientError> {
+    /// Deletes the setting value from the store. Returns `true` if `key` had a value set.
+    pub async fn remove_setting(&mut self, key: String) -> Result<bool, ClientError> {
         self.store.remove_setting(key).await.map_err(Into::into)
     }
 

--- a/crates/rust-client/src/store/mod.rs
+++ b/crates/rust-client/src/store/mod.rs
@@ -419,10 +419,10 @@ pub trait Store: Send + Sync {
         account_id: AccountId,
     ) -> Result<(), StoreError>;
 
-    /// Removes an [`Address`].
+    /// Removes an [`Address`]. Returns `true` if the address was tracked.
     ///
     /// Tag removal is the caller's responsibility — see [`Self::remove_note_tag`].
-    async fn remove_address(&self, address: Address) -> Result<(), StoreError>;
+    async fn remove_address(&self, address: Address) -> Result<bool, StoreError>;
 
     // SETTINGS
     // --------------------------------------------------------------------------------------------

--- a/crates/rust-client/src/store/mod.rs
+++ b/crates/rust-client/src/store/mod.rs
@@ -433,8 +433,8 @@ pub trait Store: Send + Sync {
     /// Retrieves a value from the `settings` table.
     async fn get_setting(&self, key: String) -> Result<Option<Vec<u8>>, StoreError>;
 
-    /// Deletes a value from the `settings` table.
-    async fn remove_setting(&self, key: String) -> Result<(), StoreError>;
+    /// Deletes a value from the `settings` table. Returns `true` if the key was present.
+    async fn remove_setting(&self, key: String) -> Result<bool, StoreError>;
 
     /// Returns all the keys from the `settings` table.
     async fn list_setting_keys(&self) -> Result<Vec<String>, StoreError>;
@@ -575,7 +575,8 @@ pub trait Store: Send + Sync {
     /// Removes the cached transaction encryption key, so the next submission fetches and verifies
     /// a fresh one. Used when the node rejects a submission sealed against a retired key.
     async fn remove_transaction_encryption_key(&self) -> Result<(), StoreError> {
-        self.remove_setting(TRANSACTION_ENCRYPTION_KEY_STORE_SETTING.into()).await
+        self.remove_setting(TRANSACTION_ENCRYPTION_KEY_STORE_SETTING.into()).await?;
+        Ok(())
     }
 
     // PARTIAL MMR

--- a/crates/sqlite-store/src/account/accounts.rs
+++ b/crates/sqlite-store/src/account/accounts.rs
@@ -419,16 +419,19 @@ impl SqliteStore {
         Ok(())
     }
 
+    /// Returns `true` if a row was deleted, `false` if the address wasn't tracked.
     pub(crate) fn remove_address(
         conn: &mut Connection,
         address: &Address,
-    ) -> Result<(), StoreError> {
+    ) -> Result<bool, StoreError> {
         let tx = conn.transaction().into_store_error()?;
         let serialized_address = address.to_bytes();
         const DELETE_QUERY: &str = "DELETE FROM addresses WHERE address = ?";
-        tx.execute(DELETE_QUERY, params![serialized_address]).into_store_error()?;
+        let count = tx.execute(DELETE_QUERY, params![serialized_address]).into_store_error()?;
 
-        tx.commit().into_store_error()
+        tx.commit().into_store_error()?;
+
+        Ok(count > 0)
     }
 
     /// Inserts an [`AccountCode`].

--- a/crates/sqlite-store/src/lib.rs
+++ b/crates/sqlite-store/src/lib.rs
@@ -532,7 +532,7 @@ impl Store for SqliteStore {
         .await
     }
 
-    async fn remove_address(&self, address: Address) -> Result<(), StoreError> {
+    async fn remove_address(&self, address: Address) -> Result<bool, StoreError> {
         self.interact_with_connection(move |conn| SqliteStore::remove_address(conn, &address))
             .await
     }

--- a/crates/sqlite-store/src/lib.rs
+++ b/crates/sqlite-store/src/lib.rs
@@ -433,7 +433,7 @@ impl Store for SqliteStore {
             .await
     }
 
-    async fn remove_setting(&self, key: String) -> Result<(), StoreError> {
+    async fn remove_setting(&self, key: String) -> Result<bool, StoreError> {
         self.interact_with_connection(move |conn| SqliteStore::remove_setting(conn, &key))
             .await
     }
@@ -454,7 +454,9 @@ impl Store for SqliteStore {
                     SettingMutation::Set { key, value } => {
                         SqliteStore::set_setting(&tx, key, value).into_store_error()?;
                     },
-                    SettingMutation::Remove { key } => SqliteStore::remove_setting(&tx, key)?,
+                    SettingMutation::Remove { key } => {
+                        SqliteStore::remove_setting(&tx, key)?;
+                    },
                 }
             }
             tx.commit().into_store_error()?;

--- a/crates/sqlite-store/src/settings.rs
+++ b/crates/sqlite-store/src/settings.rs
@@ -38,14 +38,13 @@ impl SqliteStore {
         Ok(())
     }
 
-    pub(crate) fn remove_setting(conn: &Connection, name: &str) -> Result<(), StoreError> {
+    /// Returns `true` if a row was deleted, `false` if `name` wasn't present.
+    pub(crate) fn remove_setting(conn: &Connection, name: &str) -> Result<bool, StoreError> {
         let count = conn
             .execute("DELETE FROM settings WHERE name = $1", params![name])
             .into_store_error()?;
 
-        debug_assert_eq!(count, 1);
-
-        Ok(())
+        Ok(count > 0)
     }
 
     pub(crate) fn list_setting_keys(conn: &Connection) -> Result<Vec<String>, StoreError> {

--- a/crates/testing/miden-client-tests/src/tests.rs
+++ b/crates/testing/miden-client-tests/src/tests.rs
@@ -4251,16 +4251,19 @@ async fn account_add_address_after_creation() {
     assert!(client.add_address(basic_wallet_address.clone(), account.id()).await.is_ok());
 
     // We can remove the default address and the note tag is still present
-    assert!(client.remove_address(default_address.clone(), account.id()).await.is_ok());
+    assert!(client.remove_address(default_address.clone(), account.id()).await.unwrap());
     let derived_note_tag = default_address.to_note_tag();
     let note_tag_record = NoteTagRecord::with_account_source(derived_note_tag, account.id());
     let note_tags = client.get_note_tags().await.unwrap();
     assert!(note_tags.contains(&note_tag_record));
 
     // If we remove all addresses, note tag should be removed
-    assert!(client.remove_address(basic_wallet_address.clone(), account.id()).await.is_ok());
+    assert!(client.remove_address(basic_wallet_address.clone(), account.id()).await.unwrap());
     let note_tags = client.get_note_tags().await.unwrap();
     assert!(!note_tags.contains(&note_tag_record));
+
+    // Removing an address that isn't tracked reports that nothing was removed
+    assert!(!client.remove_address(basic_wallet_address, account.id()).await.unwrap());
 
     // Then add it again
     assert!(client.add_address(default_address, account.id()).await.is_ok());


### PR DESCRIPTION
This PR changes the CLI to:
- When removing addresses for an account or removing the default address print an error if no address was set.
- When importing a file print an error if failed to read the file as note or account.