### PR TITLE
fix(cli): report the stored ID when setting the default account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 * [FIX][cli] `miden-client notes --show` now prints the note sender in the `Sender` row; it was printing the note tag there ([#2412](https://github.com/0xMiden/rust-sdk/pull/2412)).
 * [FIX][cli] `miden-client tags --add` and `--remove` now report what actually happened instead of always printing that the tag was added or removed ([#2416](https://github.com/0xMiden/rust-sdk/pull/2416)).
 * [FIX][cli] `miden-client account --default none` now reports whether a default account was actually removed instead of always printing that it was. Removing an absent setting also no longer panics in debug builds.
+* [FIX][cli] `miden-client account --default <ID>` now reports the account ID it stored; it was echoing the argument, which may be an ID prefix or a bech32 address ([#2439](https://github.com/0xMiden/rust-sdk/pull/2439)).
 * [FIX][cli] `miden-client address remove` now reports whether the address was actually removed instead of always printing that it was being removed.
 * [FIX][rust] `VerifyingRpcClient::get_account` now validates that the returned `AccountProof` belongs to the requested account ID, rejecting a mismatch with `RpcError::InvalidResponse` ([#2419](https://github.com/0xMiden/rust-sdk/pull/2419)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,8 +62,7 @@
 * [FIX][rust] `Client::prove_transaction_with` now checks that the `TransactionProver` returned a proof of the transaction it was asked to prove, rejecting a mismatch with the new `ClientError::MismatchedProvenTransaction` ([#2391](https://github.com/0xMiden/rust-sdk/pull/2391)).
 * [FIX][cli] `miden-client notes --show` now prints the note sender in the `Sender` row; it was printing the note tag there ([#2412](https://github.com/0xMiden/rust-sdk/pull/2412)).
 * [FIX][cli] `miden-client tags --add` and `--remove` now report what actually happened instead of always printing that the tag was added or removed ([#2416](https://github.com/0xMiden/rust-sdk/pull/2416)).
-* [FIX][cli] `miden-client account --default none` now reports whether a default account was actually removed instead of always printing that it was. Removing an absent setting also no longer panics in debug builds.
-* [FIX][cli] `miden-client account --default <ID>` now reports the account ID it stored; it was echoing the argument, which may be an ID prefix or a bech32 address ([#2439](https://github.com/0xMiden/rust-sdk/pull/2439)).
+* [FIX][cli] `miden-client account --default none` now reports whether a default account was actually removed instead of always printing that it was. Removing an absent setting also no longer panics in debug builds ([#2439](https://github.com/0xMiden/rust-sdk/pull/2439)).
 * [FIX][cli] `miden-client address remove` now reports whether the address was actually removed instead of always printing that it was being removed.
 * [FIX][rust] `VerifyingRpcClient::get_account` now validates that the returned `AccountProof` belongs to the requested account ID, rejecting a mismatch with `RpcError::InvalidResponse` ([#2419](https://github.com/0xMiden/rust-sdk/pull/2419)).
 

--- a/bin/miden-cli/src/commands/account.rs
+++ b/bin/miden-cli/src/commands/account.rs
@@ -143,8 +143,7 @@ impl AccountCmd {
                         client
                             .set_setting(DEFAULT_ACCOUNT_ID_KEY.to_string(), account.id())
                             .await?;
-                        // `parse_account_id` also accepts an ID prefix or a bech32 address, so
-                        // echoing the argument hides which account the setting now points at.
+
                         println!("Default account set to {}", account.id());
                     },
                 }

--- a/bin/miden-cli/src/commands/account.rs
+++ b/bin/miden-cli/src/commands/account.rs
@@ -143,7 +143,9 @@ impl AccountCmd {
                         client
                             .set_setting(DEFAULT_ACCOUNT_ID_KEY.to_string(), account.id())
                             .await?;
-                        println!("Setting default account to {id}...");
+                        // `parse_account_id` also accepts an ID prefix or a bech32 address, so
+                        // echoing the argument hides which account the setting now points at.
+                        println!("Default account set to {}", account.id());
                     },
                 }
             },


### PR DESCRIPTION
#2436 fixed the `--default none` branch. The branch right below it still reports the argument rather than what was stored.

```rust
let account_id: AccountId = parse_account_id(&client, id).await?;
let (account, _) = client.account_reader(account_id).header().await?;
client.set_setting(DEFAULT_ACCOUNT_ID_KEY.to_string(), account.id()).await?;
println!("Setting default account to {id}...");
```

The setting is written from the resolved `account.id()`, but the message prints `id` — the raw argument. [`parse_account_id`](https://github.com/0xMiden/rust-sdk/blob/next/bin/miden-cli/src/utils.rs#L57) accepts three forms:

- a full hex ID
- an **ID prefix**, resolved against the store
- a **bech32 address**

So `account --default 0x1234` confirms `0x1234` while storing the full ID, and a bech32 argument is confirmed in a form the setting does not hold. In both cases the output does not say which account the default now points at. The read branch a few lines above already prints the canonical `AccountId`; this makes the write branch match.

It also drops the progressive tense and the trailing `...`. The write is finished by the time the line prints, and the sibling branch reports as `Default account removed` / `No default account was set` after #2436 — so `Default account set to <id>` keeps the three consistent.

## Verification

`rustfmt --check` parses the file and reports no diff on the touched lines.

I could not build the workspace: on Windows `cargo check` fails inside `miden-node-proto-build` before reaching this crate, which matches CI running only on `ubuntu-*`. So this is not compiled — please let CI be the judge. The change is one `println!` argument and `AccountId` already implements `Display` here (the read branch formats it the same way at line 125), so the risk is small, but I would rather say so than imply otherwise.

## Test coverage

`account --default` has no CLI test today, and #2436 landed without one. As mentioned in #2426, I have the `list_addresses_remove` extension written and am happy to send tests for this command too — just say which you would prefer, and whether you want them in this PR or separately.
