### PR TITLE
fix(rpc): avoid retrying unavailable submissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@
 
 ### Fixes
 
+* [FIX][rust] Transaction submissions no longer retry `Unavailable` responses, avoiding a duplicate submission when the node may already have accepted the first request; read-only RPCs keep their existing retry behavior. (#2441)
+
 * [FIX][rust] `ChainAnchor` deserialization no longer panics on crafted input: a partial blockchain whose tracked leaf is missing an ancestor sibling, or whose block-map key disagrees with its header, is rejected as an invalid value, and anchors tracking more blocks than a transaction can reference are rejected early with the new `ChainAnchorError::TooManyTrackedBlocks` ([#2421](https://github.com/0xMiden/rust-sdk/pull/2421)).
 * [FIX][rust] `Client::execute_transaction_at` now fails with the new `ChainAnchorError::AnchoredTransactionExpired` when the executed transaction's expiration block has already been reached, instead of handing back a transaction the network would reject after proving ([#2421](https://github.com/0xMiden/rust-sdk/pull/2421)).
 * [FIX][rust] A request that sets `ignore_invalid_input_notes` but carries no input notes, or whose notes are all screened out, no longer fails with an out-of-range note-count error from the consumption checker ([#2421](https://github.com/0xMiden/rust-sdk/pull/2421)).

--- a/crates/rust-client/src/rpc/tonic_client/mod.rs
+++ b/crates/rust-client/src/rpc/tonic_client/mod.rs
@@ -297,9 +297,10 @@ impl GrpcClient {
     /// Executes an RPC call and automatically retries transient failures.
     ///
     /// The provided closure is invoked with a freshly connected [`ApiClient`] on each attempt.
-    /// Retries are delegated to [`retry::RetryState`], which currently handles gRPC
-    /// [`tonic::Code::ResourceExhausted`] and [`tonic::Code::Unavailable`] responses, including
-    /// honoring cooldown delays when the node provides them.
+    /// Retries are delegated to [`retry::RetryState`]. Read-only calls retry gRPC
+    /// [`tonic::Code::ResourceExhausted`] and [`tonic::Code::Unavailable`] responses, while
+    /// transaction submissions retry only [`tonic::Code::ResourceExhausted`] because an
+    /// `Unavailable` response may arrive after the node has already accepted the submission.
     ///
     /// Returns the first successful gRPC response. If the call keeps failing after retries are
     /// exhausted, or if the error is not retryable, this returns the corresponding [`RpcError`]
@@ -310,13 +311,15 @@ impl GrpcClient {
         mut call: impl FnMut(ApiClient) -> RpcFuture<Result<tonic::Response<T>, Status>>,
     ) -> Result<tonic::Response<T>, RpcError> {
         let mut retry_state = retry::RetryState::new(self.max_retries, self.retry_interval_ms);
+        let retry_unavailable =
+            !matches!(endpoint, RpcEndpoint::SubmitProvenTx | RpcEndpoint::SubmitProvenBatch);
 
         loop {
             let rpc_api = self.ensure_connected().await?;
 
             match call(rpc_api).await {
                 Ok(response) => return Ok(response),
-                Err(status) if retry_state.should_retry(&status).await => {},
+                Err(status) if retry_state.should_retry(&status, retry_unavailable).await => {},
                 Err(status) => return Err(self.rpc_error_from_status(endpoint, status)),
             }
         }

--- a/crates/rust-client/src/rpc/tonic_client/retry.rs
+++ b/crates/rust-client/src/rpc/tonic_client/retry.rs
@@ -42,8 +42,8 @@ impl RetryState {
     /// Returns `true` after waiting the requested cooldown when the error is retryable and the
     /// attempt limit has not been reached. Returns `false` for non-retryable statuses or once the
     /// retry budget is exhausted.
-    pub(super) async fn should_retry(&mut self, status: &Status) -> bool {
-        if self.attempt >= self.max_retries || !is_retryable(status) {
+    pub(super) async fn should_retry(&mut self, status: &Status, retry_unavailable: bool) -> bool {
+        if self.attempt >= self.max_retries || !is_retryable(status, retry_unavailable) {
             return false;
         }
 
@@ -64,8 +64,9 @@ impl RetryState {
 // HELPERS
 // ================================================================================================
 
-fn is_retryable(status: &Status) -> bool {
-    matches!(status.code(), tonic::Code::ResourceExhausted | tonic::Code::Unavailable)
+fn is_retryable(status: &Status, retry_unavailable: bool) -> bool {
+    matches!(status.code(), tonic::Code::ResourceExhausted)
+        || (retry_unavailable && matches!(status.code(), tonic::Code::Unavailable))
 }
 
 fn retry_delay(status: &Status, fallback_ms: u64) -> Duration {
@@ -101,12 +102,25 @@ mod tests {
     use tonic::metadata::MetadataMap;
     use tonic::{Code, Status};
 
-    use super::{DEFAULT_RETRY_INTERVAL_MS, retry_delay};
+    use super::{DEFAULT_RETRY_INTERVAL_MS, is_retryable, retry_delay};
 
     fn status_with_retry_after(retry_after: &str) -> Status {
         let mut metadata = MetadataMap::new();
         metadata.insert("retry-after", retry_after.parse().unwrap());
         Status::with_metadata(Code::ResourceExhausted, "Too Many Requests! Wait for 0s", metadata)
+    }
+
+    #[test]
+    fn unavailable_retry_can_be_disabled_for_submissions() {
+        let status = Status::unavailable("temporarily unavailable");
+        assert!(!is_retryable(&status, false));
+        assert!(is_retryable(&status, true));
+    }
+
+    #[test]
+    fn resource_exhausted_remains_retryable_for_submissions() {
+        let status = Status::resource_exhausted("rate limited");
+        assert!(is_retryable(&status, false));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #2441.

Transaction submission RPCs are not safe to retry on `Unavailable`: the node may already have accepted the first request before the response was lost, so retrying can turn a successful submission into an apparent application-level rejection.

This change makes the existing retry policy endpoint-aware:
- `SubmitProvenTx` and `SubmitProvenBatch` retry `ResourceExhausted` only;
- read-only RPCs keep retrying both `ResourceExhausted` and `Unavailable`;
- focused tests cover both submission-policy branches;
- the Unreleased changelog documents the behavior change.

## Testing

`cargo test -p miden-client rpc::tonic_client::retry --lib` ✅

The branch is based on `next` and contains one focused commit.