### PR TITLE
test: avoid blocking while polling consumable notes

### DIFF
--- a/crates/rust-client/src/test_utils/common.rs
+++ b/crates/rust-client/src/test_utils/common.rs
@@ -341,7 +341,7 @@ pub async fn wait_for_consumable_notes(
             %deadline_block,
             "No consumable notes yet, waiting..."
         );
-        std::thread::sleep(Duration::from_secs(3));
+        tokio::time::sleep(Duration::from_secs(3)).await;
     }
 }
 


### PR DESCRIPTION
## Summary

Contributes to #2440 by fixing a blocking poll in the helper used by the flaky Agglayer bridge test.

`wait_for_consumable_notes()` is async, but its retry loop used `std::thread::sleep(Duration::from_secs(3))`. That blocks a Tokio worker while the integration test is waiting for a network-produced note. The helper now uses `tokio::time::sleep(...).await`, matching the other async polling helpers in the same module and allowing the runtime to schedule other work during the cooldown.

This is intentionally scoped to the polling bug; it does not claim that increasing or changing the 60-block Agglayer timeout is the right fix for every #2440 failure.

## Verification

`cargo check -p miden-client --tests` ✅

Final duplicate check: no existing PR for #2440 or `wait_for_consumable_notes`.