### PR TITLE
fix(cli, store): pass account_id filter to list_consumable_notes and simplify sqlite get_setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Fixes
 
 * [FIX][rust] Added validation of cached transaction encryption keys during deserialization. Unsupported encryption schemes and empty or oversized key IDs are rejected before reading the key ID bytes ([#2411](https://github.com/0xMiden/rust-sdk/pull/2411)).
+* [FIX][cli] `notes --list consumable` now respects the `--account-id` filter ([#2449](https://github.com/0xMiden/rust-sdk/pull/2449)).
+* [store] Simplified `SqliteStore::get_setting` to take `&Connection` directly without opening an unnecessary transaction ([#2449](https://github.com/0xMiden/rust-sdk/pull/2449)).
 * [FIX][cli] `miden-client import` now rejects invocations without a file path instead of silently succeeding ([#2450](https://github.com/0xMiden/rust-sdk/pull/2450)).
 * [FIX][rust] `TransactionRequestBuilder::build_swap` and `build_pswap_create` now reject a zero-amount asset on either side of the exchange. A zero requested asset produced a payback P2ID note carrying nothing, and a zero offered asset produced a note whose consumer pays and receives nothing ([#2459](https://github.com/0xMiden/rust-sdk/pull/2459)).
 

--- a/bin/miden-cli/src/commands/address.rs
+++ b/bin/miden-cli/src/commands/address.rs
@@ -187,7 +187,7 @@ async fn encode_address<AUTH>(
     let routing_params = match tag_len {
         Some(tag_len) => RoutingParameters::new(interface)
             .with_note_tag_len(tag_len)
-            .map_err(|e| CliError::Address(e, String::new()))?,
+            .map_err(|e| CliError::Address(e, format!("invalid tag_len {tag_len}")))?,
         None => RoutingParameters::new(interface),
     };
     let address = Address::new(account_id).with_routing_parameters(routing_params);

--- a/bin/miden-cli/src/commands/notes.rs
+++ b/bin/miden-cli/src/commands/notes.rs
@@ -77,8 +77,8 @@ impl NotesCmd {
         mut client: Client<AUTH>,
     ) -> Result<(), CliError> {
         match self {
-            NotesCmd { list: Some(NoteFilter::Consumable), .. } => {
-                list_consumable_notes(client, None).await?;
+            NotesCmd { list: Some(NoteFilter::Consumable), account_id, .. } => {
+                list_consumable_notes(client, account_id.as_ref()).await?;
             },
             NotesCmd { list: Some(filter), .. } => {
                 list_notes(

--- a/bin/miden-cli/src/commands/notes.rs
+++ b/bin/miden-cli/src/commands/notes.rs
@@ -77,7 +77,11 @@ impl NotesCmd {
         mut client: Client<AUTH>,
     ) -> Result<(), CliError> {
         match self {
-            NotesCmd { list: Some(NoteFilter::Consumable), account_id, .. } => {
+            NotesCmd {
+                list: Some(NoteFilter::Consumable),
+                account_id,
+                ..
+            } => {
                 list_consumable_notes(client, account_id.as_ref()).await?;
             },
             NotesCmd { list: Some(filter), .. } => {

--- a/crates/sqlite-store/src/settings.rs
+++ b/crates/sqlite-store/src/settings.rs
@@ -13,19 +13,17 @@ use crate::{insert_sql, subst};
 
 impl SqliteStore {
     pub(crate) fn get_setting<T: FromSql>(
-        conn: &mut Connection,
+        conn: &Connection,
         scope: SettingScope,
         name: &str,
     ) -> Result<Option<T>, StoreError> {
-        conn.transaction()
-            .into_store_error()?
-            .query_row(
-                "SELECT value FROM settings WHERE scope = $1 AND name = $2",
-                params![scope.as_u8(), name],
-                |row| row.get(0),
-            )
-            .optional()
-            .into_store_error()
+        conn.query_row(
+            "SELECT value FROM settings WHERE scope = $1 AND name = $2",
+            params![scope.as_u8(), name],
+            |row| row.get(0),
+        )
+        .optional()
+        .into_store_error()
     }
 
     pub(crate) fn set_setting<T: ToSql>(


### PR DESCRIPTION
In bin/miden-cli/src/commands/notes.rs, passed account_id.as_ref() to list_consumable_notes when listing consumable notes so the --account-id CLI filter is respected. In crates/sqlite-store/src/settings.rs, simplified get_setting to take &Connection and query directly without opening an unnecessary transaction for a SELECT query.