### PR TITLE
fix(cli): require file path for import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 * [FIX][cli] `miden-client notes --show` now prints the note sender in the `Sender` row; it was printing the note tag there ([#2412](https://github.com/0xMiden/rust-sdk/pull/2412)).
 * [FIX][cli] `miden-client tags --add` and `--remove` now report what actually happened instead of always printing that the tag was added or removed ([#2416](https://github.com/0xMiden/rust-sdk/pull/2416)).
 * [FIX][cli] `miden-client account --default none` now reports whether a default account was actually removed instead of always printing that it was. Removing an absent setting also no longer panics in debug builds ([#2439](https://github.com/0xMiden/rust-sdk/pull/2439)).
+* [FIX][cli] `miden-client import` now rejects invocations without a file path instead of silently succeeding.
 * [FIX][cli] `miden-client address remove` now reports whether the address was actually removed instead of always printing that it was being removed.
 * [FIX][rust] `VerifyingRpcClient::get_account` now validates that the returned `AccountProof` belongs to the requested account ID, rejecting a mismatch with `RpcError::InvalidResponse` ([#2419](https://github.com/0xMiden/rust-sdk/pull/2419)).
 

--- a/bin/miden-cli/src/commands/import.rs
+++ b/bin/miden-cli/src/commands/import.rs
@@ -16,7 +16,7 @@ use crate::{FilesystemKeyStore, Parser};
 #[command(about = "Import notes or accounts")]
 pub struct ImportCmd {
     /// Paths to the files that contains the account/note data.
-    #[arg()]
+    #[arg(required = true)]
     filenames: Vec<PathBuf>,
     /// Only relevant for accounts. If set, the account will be overwritten if it already exists.
     #[arg(short, long, default_value_t = false)]

--- a/bin/miden-cli/tests/cli.rs
+++ b/bin/miden-cli/tests/cli.rs
@@ -943,7 +943,10 @@ fn cli_empty_commands() {
     );
 
     let mut import_cmd = cargo_bin_cmd!("miden-client");
-    assert_command_fails_but_does_not_panic(import_cmd.args(["export"]).current_dir(&temp_dir));
+    assert_command_fails_but_does_not_panic(import_cmd.args(["import"]).current_dir(&temp_dir));
+
+    let mut export_cmd = cargo_bin_cmd!("miden-client");
+    assert_command_fails_but_does_not_panic(export_cmd.args(["export"]).current_dir(&temp_dir));
 
     let mut mint_cmd = cargo_bin_cmd!("miden-client");
     assert_command_fails_but_does_not_panic(mint_cmd.args(["mint"]).current_dir(&temp_dir));


### PR DESCRIPTION
`miden-client import` accepted an empty invocation because the filename list was optional, so it initialized the client and exited successfully without importing anything.

This makes the filename argument required and adds it to the existing empty-command CLI regression test.

Testing:
- `cargo test -p miden-client-cli --test integration cli_empty_commands -- --exact --nocapture`
- `./target/debug/miden-client import`
- `./target/debug/miden-client import --help`
- `cargo clippy -p miden-client-cli --all-targets -- -D warnings`