### PR TITLE
fix(rust-client): reject a zero-amount fungible mint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 * [FIX][cli] `miden-client account --default none` now reports whether a default account was actually removed instead of always printing that it was. Removing an absent setting also no longer panics in debug builds ([#2439](https://github.com/0xMiden/rust-sdk/pull/2439)).
 * [FIX][cli] `miden-client address remove` now reports whether the address was actually removed instead of always printing that it was being removed.
 * [FIX][rust] `VerifyingRpcClient::get_account` now validates that the returned `AccountProof` belongs to the requested account ID, rejecting a mismatch with `RpcError::InvalidResponse` ([#2419](https://github.com/0xMiden/rust-sdk/pull/2419)).
+* [FIX][rust] `TransactionRequestBuilder::build_mint_fungible_asset` now rejects a zero-amount asset with `TransactionRequestError::P2IDNoteWithoutAsset`, matching `build_pay_to_id`; both emit a P2ID note, and minting nothing produced one the target could draw nothing from ([#2457](https://github.com/0xMiden/rust-sdk/pull/2457)).
 
 ## 0.16.0-alpha.1 (2026-07-17)
 

--- a/crates/rust-client/src/transaction/request/builder.rs
+++ b/crates/rust-client/src/transaction/request/builder.rs
@@ -327,7 +327,8 @@ impl TransactionRequestBuilder {
     /// Consumes the builder and returns a [`TransactionRequest`] for a transaction to mint fungible
     /// assets. This request must be executed against a fungible faucet account.
     ///
-    /// - `asset` is the fungible asset to be minted.
+    /// - `asset` is the fungible asset to be minted. The amount must be non-zero: minting nothing
+    ///   would emit a P2ID note the target cannot draw anything from.
     /// - `target_id` is the account ID of the account to receive the minted asset.
     /// - `note_type` determines the visibility of the note to be created.
     /// - `rng` is the random number generator used to generate the serial number for the created
@@ -341,6 +342,13 @@ impl TransactionRequestBuilder {
         note_type: NoteType,
         rng: &mut ClientRng,
     ) -> Result<TransactionRequest, TransactionRequestError> {
+        // Minting emits a P2ID note, and a P2ID note carrying nothing is rejected on the transfer
+        // path for the same reason: it costs a transaction and leaves the target a note with
+        // nothing to consume.
+        if asset.amount() == AssetAmount::ZERO {
+            return Err(TransactionRequestError::P2IDNoteWithoutAsset);
+        }
+
         let created_note = P2idNote::builder()
             .sender(asset.faucet_id())
             .target(target_id)

--- a/crates/testing/miden-client-tests/src/tests.rs
+++ b/crates/testing/miden-client-tests/src/tests.rs
@@ -1150,6 +1150,18 @@ async fn note_without_asset() {
         .unwrap_err();
 
     assert!(matches!(error, TransactionRequestError::P2IDNoteWithoutAsset));
+
+    // Minting emits a P2ID note as well, so a zero-amount mint is turned away the same way.
+    let error = TransactionRequestBuilder::new()
+        .build_mint_fungible_asset(
+            FungibleAsset::new(faucet.id(), 0).unwrap(),
+            wallet.id(),
+            NoteType::Public,
+            client.rng(),
+        )
+        .unwrap_err();
+
+    assert!(matches!(error, TransactionRequestError::P2IDNoteWithoutAsset));
 }
 
 #[tokio::test]


### PR DESCRIPTION
### Problem

`build_pay_to_id` treats a P2ID note with nothing in it as an error:

```rust
if payment_data.assets().iter().all(|asset| {
    asset.is_fungible() && asset.unwrap_fungible().amount().as_u64() == 0
}) {
    return Err(TransactionRequestError::P2IDNoteWithoutAsset);
}
```

`note_without_asset` already pins that down for both the empty-asset and the zero-amount case.

`build_mint_fungible_asset` emits a P2ID note too - same `P2idNote::builder()` - and has no such check, so a zero-amount asset builds a request:

```
FungibleAsset::new(faucet, 0)  -> Ok, amount=0
build_mint_fungible_asset(0)   -> Ok
build_pay_to_id(0)             -> Err(P2IDNoteWithoutAsset)
```

The note that comes out carries `Fungible(FungibleAsset { .., amount: AssetAmount(0) })`. It reaches execution, proving and submission before anyone notices there is nothing in it, and the target is left a note it can draw nothing from. The CLI hands its parsed asset straight to this constructor, so `mint --asset 0::<faucet>` follows the same path.

### Change

Reject a zero amount in `build_mint_fungible_asset` with the existing `P2IDNoteWithoutAsset`. The variant fits as-is: its message is "pay-to-ID note must contain at least one asset to transfer", and its `ErrorHint` already tells the user to add an asset, which is the right advice here.

No new error variant, and no caller in the repo mints zero.

### Test plan

```
cargo test -p miden-client-unit-tests -- mint note_without_asset
```

Extended `note_without_asset` with the mint case rather than adding a separate test, since it is already the test for this invariant. It fails on `next`, where `unwrap_err` panics on the `Ok` request and prints the zero-amount note it built.

`mint_transaction` still passes, as do the 122 `miden-client` lib tests. The full unit-test suite runs past 15 minutes locally, so I limited it to the mint-related tests and am relying on CI for the rest.
