### PR TITLE
chore: update node to `v0.16.0-rc.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2428,7 +2428,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-bench"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2484,7 +2484,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-cli"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-integration-tests"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2535,7 +2535,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-sqlite-store"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2553,7 +2553,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-unit-tests"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "miden-client",
  "miden-client-sqlite-store",
@@ -5126,7 +5126,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-node-genesis"
-version = "0.16.0-rc.2"
+version = "0.16.0-rc.3"
 dependencies = [
  "anyhow",
  "miden-agglayer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2886,8 +2886,9 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto-build"
-version = "0.16.0-rc.1"
-source = "git+https://github.com/0xMiden/node.git?branch=next#1b036399c940e710f8c507b18737abaf54414988"
+version = "0.16.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "412f0cd0a3b7f9c2a177f202c39e79467dd9d6c5d9d4633bcd41e010057bf67a"
 dependencies = [
  "build-rs",
  "codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ edition      = "2024"
 license      = "MIT"
 repository   = "https://github.com/0xMiden/rust-sdk"
 rust-version = "1.96"
-version      = "0.16.0-rc.2"
+version      = "0.16.0-rc.3"
 
 [profile.dev]
 codegen-units = 16
@@ -36,8 +36,8 @@ opt-level = 1
 
 [workspace.dependencies]
 # Workspace crates
-miden-client              = { default-features = false, path = "crates/rust-client", version = "0.16.0-rc.2" }
-miden-client-sqlite-store = { default-features = false, path = "crates/sqlite-store", version = "0.16.0-rc.2" }
+miden-client              = { default-features = false, path = "crates/rust-client", version = "0.16.0-rc.3" }
+miden-client-sqlite-store = { default-features = false, path = "crates/sqlite-store", version = "0.16.0-rc.3" }
 
 # Miden protocol dependencies
 miden-agglayer  = { default-features = false, version = "0.16.0-rc.6" }
@@ -91,5 +91,4 @@ missing_panics_doc          = "allow" # TODO: fixup and enable this.
 module_name_repetitions     = "allow" # Many triggers, and is a stylistic choice.
 must_use_candidate          = "allow" # This marks many fn's which isn't helpful.
 should_panic_without_expect = "allow" # We don't care about the specific panic message.
-unused_async_trait_impl     = "allow" # Trait signatures require async even when an impl has nothing to await.
 # End of pedantic lints.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ miden-tx        = { default-features = false, version = "0.16.0-rc.6" }
 miden-tx-batch  = { default-features = false, version = "0.16.0-rc.6" }
 
 # Miden node dependencies
-miden-node-proto-build           = { branch = "next", default-features = false, git = "https://github.com/0xMiden/node.git" } # TODO: switch to crates.io release once available
+miden-node-proto-build           = { default-features = false, version = "0.16.0-rc.2" }
 miden-note-transport-proto-build = { default-features = false, version = "0.5.0-alpha.1" }
 
 # Miden debug dependency
@@ -91,4 +91,5 @@ missing_panics_doc          = "allow" # TODO: fixup and enable this.
 module_name_repetitions     = "allow" # Many triggers, and is a stylistic choice.
 must_use_candidate          = "allow" # This marks many fn's which isn't helpful.
 should_panic_without_expect = "allow" # We don't care about the specific panic message.
+unused_async_trait_impl     = "allow" # Trait signatures require async even when an impl has nothing to await.
 # End of pedantic lints.


### PR DESCRIPTION
Update node dep to `v0.16.0-rc.2` and prepare client release `v0.16.0-rc.3`.