### PR TITLE
fix(rust-client): reject zero-amount assets in swap and pswap notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+* [BREAKING][type][rust] Added the `TransactionRequestError::SwapNoteWithZeroAsset` variant, so exhaustive matches on `TransactionRequestError` must handle it ([#2459](https://github.com/0xMiden/rust-sdk/pull/2459)).
+
 ### Fixes
 
 * [FIX][cli] `miden-client import` now rejects invocations without a file path instead of silently succeeding ([#2450](https://github.com/0xMiden/rust-sdk/pull/2450)).
+* [FIX][rust] `TransactionRequestBuilder::build_swap` and `build_pswap_create` now reject a zero-amount asset on either side of the exchange. A zero requested asset produced a payback P2ID note carrying nothing, and a zero offered asset produced a note whose consumer pays and receives nothing ([#2459](https://github.com/0xMiden/rust-sdk/pull/2459)).
 
 ## 0.16.0 (2026-09-07)
 

--- a/crates/rust-client/src/errors.rs
+++ b/crates/rust-client/src/errors.rs
@@ -396,6 +396,14 @@ impl From<&TransactionRequestError> for Option<ErrorHint> {
                           Add at least one fungible or non-fungible asset to the note.".to_string(),
                 docs_url: Some(TROUBLESHOOTING_DOC),
             }),
+            TransactionRequestError::SwapNoteWithZeroAsset(side) => Some(ErrorHint {
+                message: format!(
+                    "A swap note exchanges the offered asset for the requested one, and its \
+                     payback is a P2ID note carrying the requested asset. A zero {side} asset \
+                     leaves one side of that exchange empty. Set a non-zero amount."
+                ),
+                docs_url: Some(TROUBLESHOOTING_DOC),
+            }),
             TransactionRequestError::OutputNoteSenderMismatch { expected, actual } => {
                 Some(ErrorHint {
                     message: format!(

--- a/crates/rust-client/src/transaction/request/builder.rs
+++ b/crates/rust-client/src/transaction/request/builder.rs
@@ -430,7 +430,8 @@ impl TransactionRequestBuilder {
     /// note. This request must be executed against the wallet sender account.
     ///
     /// - `swap_data` is the data for the swap transaction that contains the sender account ID, the
-    ///   offered asset, and the requested asset.
+    ///   offered asset, and the requested asset. Neither asset may be a zero-amount fungible asset:
+    ///   the SWAP note holds the offered one and its payback note holds the requested one.
     /// - `note_type` determines the visibility of the note to be created.
     /// - `payback_note_type` determines the visibility of the payback note.
     /// - `rng` is the random number generator used to generate the serial number for the created
@@ -444,6 +445,16 @@ impl TransactionRequestBuilder {
         payback_note_type: NoteType,
         rng: &mut ClientRng,
     ) -> Result<TransactionRequest, TransactionRequestError> {
+        // Both sides carry value: the SWAP note holds the offered asset, and filling it emits a
+        // P2ID payback carrying the requested one. A zero amount on either side leaves one of those
+        // two notes empty.
+        if is_zero_fungible(&swap_data.offered_asset()) {
+            return Err(TransactionRequestError::SwapNoteWithZeroAsset("offered"));
+        }
+        if is_zero_fungible(&swap_data.requested_asset()) {
+            return Err(TransactionRequestError::SwapNoteWithZeroAsset("requested"));
+        }
+
         // The created note is the one that we need as the output of the tx, the other one is the
         // one that we expect to receive and consume eventually.
         let swap_note = SwapNote::builder()
@@ -521,6 +532,14 @@ impl TransactionRequestBuilder {
         note_attachment: Option<NoteAttachment>,
         rng: &mut ClientRng,
     ) -> Result<TransactionRequest, TransactionRequestError> {
+        // Same exchange invariant as build_swap; PSWAP is fungible on both sides.
+        if is_zero_fungible(&pswap_data.offered_asset().into()) {
+            return Err(TransactionRequestError::SwapNoteWithZeroAsset("offered"));
+        }
+        if is_zero_fungible(&pswap_data.requested_asset().into()) {
+            return Err(TransactionRequestError::SwapNoteWithZeroAsset("requested"));
+        }
+
         let storage = PswapNoteStorage::builder()
             .min_requested_asset(pswap_data.requested_asset())
             .creator_account_id(pswap_data.creator_account_id())
@@ -678,6 +697,12 @@ impl TransactionRequestBuilder {
 
         Ok(request)
     }
+}
+
+/// Returns `true` when `asset` is a fungible asset carrying no value. Non-fungible assets always
+/// carry value, so they are never zero.
+fn is_zero_fungible(asset: &Asset) -> bool {
+    asset.is_fungible() && asset.unwrap_fungible().amount() == AssetAmount::ZERO
 }
 
 // PAYMENT NOTE DESCRIPTION

--- a/crates/rust-client/src/transaction/request/mod.rs
+++ b/crates/rust-client/src/transaction/request/mod.rs
@@ -616,6 +616,8 @@ pub enum TransactionRequestError {
     NoteArgError(#[source] NoteError),
     #[error("pay-to-ID note must contain at least one asset to transfer")]
     P2IDNoteWithoutAsset,
+    #[error("swap note assets must be non-zero: a zero {0} asset makes the exchange one-sided")]
+    SwapNoteWithZeroAsset(&'static str),
     #[error(
         "non-fungible asset issued by faucet {0} is not available in the account vault or incoming notes"
     )]

--- a/crates/testing/miden-client-tests/src/tests.rs
+++ b/crates/testing/miden-client-tests/src/tests.rs
@@ -1167,6 +1167,78 @@ async fn note_without_asset() {
 }
 
 #[tokio::test]
+async fn swap_note_with_zero_asset() {
+    let (mut client, _rpc_api, keystore) = Box::pin(create_test_client()).await;
+
+    let faucet = insert_new_fungible_faucet(&mut client, AccountType::Private, &keystore)
+        .await
+        .unwrap();
+
+    let wallet = insert_new_wallet(&mut client, AccountType::Private, &keystore).await.unwrap();
+
+    client.sync_state().await.unwrap();
+
+    // A swap exchanges the offered asset for the requested one, and filling it emits a P2ID payback
+    // carrying the requested asset, so neither side may be zero.
+    let other_faucet = insert_new_fungible_faucet(&mut client, AccountType::Private, &keystore)
+        .await
+        .unwrap();
+
+    let zero_asset = Asset::Fungible(FungibleAsset::new(faucet.id(), 0).unwrap());
+    let some_asset = Asset::Fungible(FungibleAsset::new(other_faucet.id(), 100).unwrap());
+
+    let error = TransactionRequestBuilder::new()
+        .build_swap(
+            &SwapTransactionData::new(wallet.id(), zero_asset, some_asset),
+            NoteType::Public,
+            NoteType::Private,
+            client.rng(),
+        )
+        .unwrap_err();
+
+    assert!(matches!(error, TransactionRequestError::SwapNoteWithZeroAsset("offered")));
+
+    let error = TransactionRequestBuilder::new()
+        .build_swap(
+            &SwapTransactionData::new(wallet.id(), some_asset, zero_asset),
+            NoteType::Public,
+            NoteType::Private,
+            client.rng(),
+        )
+        .unwrap_err();
+
+    assert!(matches!(error, TransactionRequestError::SwapNoteWithZeroAsset("requested")));
+
+    // PSWAP carries the same exchange, fungible on both sides.
+    let zero = FungibleAsset::new(faucet.id(), 0).unwrap();
+    let some = FungibleAsset::new(other_faucet.id(), 100).unwrap();
+
+    let error = TransactionRequestBuilder::new()
+        .build_pswap_create(
+            &PswapTransactionData::new(wallet.id(), zero, some),
+            NoteType::Public,
+            NoteType::Private,
+            None,
+            client.rng(),
+        )
+        .unwrap_err();
+
+    assert!(matches!(error, TransactionRequestError::SwapNoteWithZeroAsset("offered")));
+
+    let error = TransactionRequestBuilder::new()
+        .build_pswap_create(
+            &PswapTransactionData::new(wallet.id(), some, zero),
+            NoteType::Public,
+            NoteType::Private,
+            None,
+            client.rng(),
+        )
+        .unwrap_err();
+
+    assert!(matches!(error, TransactionRequestError::SwapNoteWithZeroAsset("requested")));
+}
+
+#[tokio::test]
 async fn execute_program() {
     let (mut client, _, keystore) = Box::pin(create_test_client()).await;
     let _ = client.sync_state().await.unwrap();


### PR DESCRIPTION
### Problem

Follow-up to #2457, which closed the same hole on `build_mint_fungible_asset`. The remaining note builders still take a zero-amount asset:

```
build_swap(offered=0,   requested=100) -> Ok
build_swap(offered=100, requested=0)   -> Ok
build_pswap_create(offered=0,   requested=100) -> Ok
build_pswap_create(offered=100, requested=0)   -> Ok
```

Both sides of a swap are supposed to carry value. `SwapNote`'s own docs describe it: the consumer takes the offered asset and "the script creates a P2ID payback note carrying the requested asset" back to the creator.

So `requested = 0` builds a swap whose payback is a P2ID note carrying nothing - the exact case `build_pay_to_id` rejects with `P2IDNoteWithoutAsset`, and the one #2457 just closed for minting. And `offered = 0` builds a note whose consumer hands over the requested asset and receives nothing.

I should have covered these in #2457; I only looked at the mint path at the time.

### Change

Reject a zero-amount asset on either side of `build_swap` and `build_pswap_create`.

`P2IDNoteWithoutAsset` does not fit here - the offered side is not a P2ID note, and its message and hint are about a P2ID transfer - so this adds `SwapNoteWithZeroAsset`, carrying which side was zero. It follows `ZeroExpirationDelta` in spirit, and gets an `ErrorHint` like the neighbouring variants.

`TransactionRequestError` is not `#[non_exhaustive]`, so the new variant is a breaking change for downstream exhaustive matches; the CHANGELOG records it as such.

Swap assets are `Asset`, so the zero test goes through a small `is_zero_fungible` helper - non-fungible assets always carry value. PSWAP is fungible on both sides and compares directly.

### Test plan

```
cargo test -p miden-client-unit-tests -- note_without_asset swap_note_with_zero_asset
```

`swap_note_with_zero_asset` covers all four cases above. It fails on `next`: with the guards removed the first `unwrap_err` panics on an `Ok` request.

It is a separate test rather than more cases inside `note_without_asset` because appending there pushed that function past `clippy::too_many_lines`.

122 `miden-client` lib tests still pass. The full unit-test suite runs past 15 minutes locally, so I ran the affected tests and am relying on CI for the rest.
