### PR TITLE
fix(cli): export --account writes the .mac file with 0600 permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 
 ### Fixes
 
+* [FIX][cli] `export --account` now writes the exported `.mac` file (which carries the account's `auth_secret_keys`) with `0600` permissions on Unix from the moment of creation, and forces them to `0600` again afterwards in case a file already existed at that path with looser permissions - the same file-permission gap #1833 fixed for the filesystem keystore and the SQLite database, but not for this CLI export path ([#2469](https://github.com/0xMiden/rust-sdk/pull/2469)).
 * [FIX][rust] `ChainAnchor` deserialization no longer panics on crafted input: a partial blockchain whose tracked leaf is missing an ancestor sibling, or whose block-map key disagrees with its header, is rejected as an invalid value, and anchors tracking more blocks than a transaction can reference are rejected early with the new `ChainAnchorError::TooManyTrackedBlocks` ([#2421](https://github.com/0xMiden/rust-sdk/pull/2421)).
 * [FIX][rust] `Client::execute_transaction_at` now fails with the new `ChainAnchorError::AnchoredTransactionExpired` when the executed transaction's expiration block has already been reached, instead of handing back a transaction the network would reject after proving ([#2421](https://github.com/0xMiden/rust-sdk/pull/2421)).
 * [FIX][rust] A request that sets `ignore_invalid_input_notes` but carries no input notes, or whose notes are all screened out, no longer fails with an out-of-range note-count error from the consumption checker ([#2421](https://github.com/0xMiden/rust-sdk/pull/2421)).

--- a/bin/miden-cli/src/commands/export.rs
+++ b/bin/miden-cli/src/commands/export.rs
@@ -106,8 +106,10 @@ async fn export_account<AUTH>(
     };
 
     info!("Writing file to {}", file_path.to_string_lossy());
-    let mut file = File::create(file_path)?;
+    let mut file = create_secret_data_file(&file_path)?;
     account_data.write_into(&mut file);
+    #[cfg(unix)]
+    restrict_secret_data_file_permissions(&file_path)?;
 
     println!("Successfully exported account {account_id}");
     Ok(file)
@@ -150,4 +152,75 @@ async fn export_note<AUTH: Keystore + Sync>(
 
     println!("Successfully exported note {note_id}");
     Ok(file)
+}
+
+// HELPERS
+// ================================================================================================
+
+/// Creates a file for writing account secret data (the exported `.mac` file's `auth_secret_keys`),
+/// restricted to owner-only access (`0600`) on Unix from the moment of creation.
+fn create_secret_data_file(path: &std::path::Path) -> std::io::Result<File> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        std::fs::OpenOptions::new().write(true).create(true).truncate(true).mode(0o600).open(path)
+    }
+    #[cfg(not(unix))]
+    {
+        File::create(path)
+    }
+}
+
+/// Forces `path` to owner-only (`0600`) permissions on Unix, in case a file already existed at
+/// that path with looser permissions before this export - `OpenOptions::mode` only applies when
+/// a file is newly created, not when an existing one is truncated and reopened for writing.
+#[cfg(unix)]
+fn restrict_secret_data_file_permissions(path: &std::path::Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::os::unix::fs::PermissionsExt;
+
+    use super::{create_secret_data_file, restrict_secret_data_file_permissions};
+
+    fn unique_temp_path(label: &str) -> std::path::PathBuf {
+        std::env::temp_dir()
+            .join(format!("miden-cli-export-test-{label}-{}", std::process::id()))
+    }
+
+    /// A freshly created export file must be `0600` from the start.
+    #[test]
+    fn newly_created_secret_data_file_is_0600() {
+        let path = unique_temp_path("new");
+        let _ = std::fs::remove_file(&path);
+
+        let file = create_secret_data_file(&path).expect("failed to create file");
+        let mode = file.metadata().unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "expected 0600 on creation, got {mode:o}");
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Overwriting a pre-existing, loosely-permissioned export file must still end up `0600`
+    /// - `OpenOptions::mode` alone (as used by `create_secret_data_file`) would silently leave a
+    /// pre-existing file's looser permissions in place, which is exactly why `export_account`
+    /// also calls `restrict_secret_data_file_permissions` afterwards.
+    #[test]
+    fn overwriting_an_existing_export_file_still_ends_up_0600() {
+        let path = unique_temp_path("overwrite");
+        std::fs::write(&path, b"stale contents").expect("failed to pre-create file");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644))
+            .expect("failed to set initial permissions");
+
+        let _file = create_secret_data_file(&path).expect("failed to open file");
+        restrict_secret_data_file_permissions(&path).expect("failed to restrict permissions");
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "expected 0600 after overwrite, got {mode:o}");
+
+        let _ = std::fs::remove_file(&path);
+    }
 }


### PR DESCRIPTION
`export_account` writes `AccountFile` (whose `auth_secret_keys` field carries the account's raw secret keys) to disk via plain `File::create()`, which on Unix creates the file with the process's default umask permissions (typically `0644` - world-readable). Any local user on a shared machine could read another user's exported account secret keys from this file.

### Context

#1833 (merged) already audited and fixed this exact class of issue for the filesystem keystore (`crates/rust-client/src/keystore/fs_keystore.rs`) and the SQLite database (`crates/sqlite-store/src/db_management/pool_manager.rs`), but didn't cover this CLI export command, which writes the same kind of secret key material to an arbitrary, user-chosen path.

### Fix

Adds two small helpers mirroring the fix already applied to `fs_keystore.rs` (see #2468): `create_secret_data_file` opens with `OpenOptions::mode(0o600)` on Unix so the file is `0600` from creation, and `restrict_secret_data_file_permissions` calls `set_permissions(0o600)` explicitly afterwards, since `OpenOptions::mode` only applies when a file is newly created - it has no effect if a file already existed at that path (e.g. a stale export left over from a previous run) and is truncated and reopened for writing instead. `export_note` (which writes public note data, not secret keys) is left unchanged.

### Test plan

Added two unit tests on the helpers directly, without needing the full async `Client`/keystore setup `export_account` itself requires: one asserting a freshly created file is `0600`, one asserting a pre-existing `0644` file still ends up `0600` after being overwritten.

Ran locally, not just CI:
```
cargo test -p miden-client-cli newly_created_secret_data_file_is_0600 -- --nocapture
cargo test -p miden-client-cli overwriting_an_existing_export_file_still_ends_up_0600 -- --nocapture
cargo test -p miden-client-cli --lib
```
Both new tests: `ok`. Full lib suite: `8 passed, 0 failed` - no regressions.