### PR TITLE
fix(ci): align declared MSRV with locked dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 
 ### Fixes
 
+* [FIX][build] Raised the declared minimum supported Rust version to 1.96.1, matching the locked Miden dependencies and restoring the nightly MSRV check ([#2471](https://github.com/0xMiden/rust-sdk/issues/2471)).
 * [FIX][rust] `ChainAnchor` deserialization no longer panics on crafted input: a partial blockchain whose tracked leaf is missing an ancestor sibling, or whose block-map key disagrees with its header, is rejected as an invalid value, and anchors tracking more blocks than a transaction can reference are rejected early with the new `ChainAnchorError::TooManyTrackedBlocks` ([#2421](https://github.com/0xMiden/rust-sdk/pull/2421)).
 * [FIX][rust] `Client::execute_transaction_at` now fails with the new `ChainAnchorError::AnchoredTransactionExpired` when the executed transaction's expiration block has already been reached, instead of handing back a transaction the network would reject after proving ([#2421](https://github.com/0xMiden/rust-sdk/pull/2421)).
 * [FIX][rust] A request that sets `ignore_invalid_input_notes` but carries no input notes, or whose notes are all screened out, no longer fails with an out-of-range note-count error from the consumption checker ([#2421](https://github.com/0xMiden/rust-sdk/pull/2421)).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ make install-tools
 ## Code Style
 
 ### Rust
-- Edition 2024, MSRV 1.96
+- Edition 2024, MSRV 1.96.1
 - Use section headers for major code sections:
   ```rust
   // SECTION NAME

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ authors      = ["miden contributors"]
 edition      = "2024"
 license      = "MIT"
 repository   = "https://github.com/0xMiden/rust-sdk"
-rust-version = "1.96"
+rust-version = "1.96.1"
 version      = "0.16.0-rc.3"
 
 [profile.dev]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/0xMiden/rust-sdk/blob/HEAD/LICENSE)
 [![test](https://github.com/0xMiden/rust-sdk/actions/workflows/test.yml/badge.svg)](https://github.com/0xMiden/rust-sdk/actions/workflows/test.yml)
 [![build](https://github.com/0xMiden/rust-sdk/actions/workflows/build.yml/badge.svg)](https://github.com/0xMiden/rust-sdk/actions/workflows/build.yml)
-[![RUST_VERSION](https://img.shields.io/badge/rustc-1.96+-lightgray.svg)](https://www.rust-lang.org/tools/install)
+[![RUST_VERSION](https://img.shields.io/badge/rustc-1.96.1+-lightgray.svg)](https://www.rust-lang.org/tools/install)
 [![crates.io](https://img.shields.io/crates/v/miden-client)](https://crates.io/crates/miden-client)
 
 This repository contains the Miden client, which provides a way to execute and prove transactions, facilitating the interaction with the Miden rollup.

--- a/bin/miden-cli/README.md
+++ b/bin/miden-cli/README.md
@@ -4,7 +4,7 @@ This binary allows the user to interact with the Miden rollup via a simple comma
 
 ## Usage
 
-Before you can use the Miden client, you'll need to make sure you have [Rust](https://www.rust-lang.org/tools/install) installed. Miden client requires rust version **1.96** or higher.
+Before you can use the Miden client, you'll need to make sure you have [Rust](https://www.rust-lang.org/tools/install) installed. Miden client requires rust version **1.96.1** or higher.
 
 ### Running `miden-client`'s CLI
 

--- a/docs/external/src/rust-client/install-and-run.md
+++ b/docs/external/src/rust-client/install-and-run.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 
 ## Software prerequisites
 
-- [Rust installation](https://www.rust-lang.org/tools/install) minimum version 1.96.
+- [Rust installation](https://www.rust-lang.org/tools/install) minimum version 1.96.1.
 
 ## Install the client
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel    = "1.96"
+channel    = "1.96.1"
 components = ["clippy", "rust-src", "rustfmt"]
 profile    = "minimal"


### PR DESCRIPTION
Closes #2471.

## What changed

- raised the workspace `rust-version` and pinned toolchain from `1.96` to `1.96.1`
- aligned the README badge, CLI prerequisite, external installation guide, and contributor guidance with the effective minimum
- added an unreleased changelog entry

## Why

The current lockfile resolves multiple Miden packages that require Rust 1.96.1. Because the workspace still declared 1.96, `cargo msrv verify` selected Rust 1.96.0 and failed before compilation. This change aligns the declared MSRV with the dependency floor; it does not modify dependencies or `Cargo.lock`.

## Verification

- `cargo msrv show --manifest-path bin/miden-cli/Cargo.toml` reports Rust 1.96.1
- `cargo msrv verify --manifest-path bin/miden-cli/Cargo.toml` reports `Is compatible`
- `cargo check --locked --manifest-path bin/miden-cli/Cargo.toml` passes with Rust 1.96.1
- `make format-check` passes

As a negative control, the same locked graph remains rejected by Rust 1.96.0 because its Miden dependencies require 1.96.1.
