### PR TITLE
fix(test): make generated integration test sources independent of filesystem order

### DIFF
--- a/bin/integration-tests/build.rs
+++ b/bin/integration-tests/build.rs
@@ -7,8 +7,8 @@
 //! The generated files are included via `include!()` macro to keep them out of the source tree.
 //! Test functions are discovered by looking for functions named `test_*`.
 
-use std::collections::HashSet;
-use std::path::Path;
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
 use std::{env, fs};
 
 const TEST_PREFIX: &str = "test_";
@@ -142,11 +142,15 @@ fn collect_test_cases() -> Vec<TestCaseInfo> {
 }
 
 /// Recursively scans directories for test functions.
+///
+/// Entries are sorted so the generated sources depend only on the directory's contents, not on the
+/// order the filesystem happens to report them in.
 fn collect_test_cases_recursive(current_dir: &Path, test_cases: &mut Vec<TestCaseInfo>) {
-    for entry in fs::read_dir(current_dir).unwrap() {
-        let entry = entry.unwrap();
-        let path = entry.path();
+    let mut entries: Vec<PathBuf> =
+        fs::read_dir(current_dir).unwrap().map(|entry| entry.unwrap().path()).collect();
+    entries.sort();
 
+    for path in entries {
         if path.is_dir() {
             collect_test_cases_recursive(&path, test_cases);
         } else if path.extension().and_then(|s| s.to_str()) == Some("rs") {
@@ -379,7 +383,7 @@ fn generate_integration_tests(test_cases: &[TestCaseInfo]) -> String {
     result.push('\n');
 
     // Collect unique imports for test modules
-    let mut modules = HashSet::new();
+    let mut modules = BTreeSet::new();
     for test_case in test_cases {
         let module_path = &test_case.module_path;
         modules.insert(module_path);
@@ -460,7 +464,7 @@ fn generate_test_case_vector(test_cases: &[TestCaseInfo]) -> String {
     result.push('\n');
 
     // Collect unique imports
-    let mut modules = HashSet::new();
+    let mut modules = BTreeSet::new();
     for test_case in test_cases {
         let module_path = &test_case.module_path;
         modules.insert(module_path);


### PR DESCRIPTION
`bin/integration-tests/build.rs` walks `src/tests` with an unsorted `fs::read_dir` and collects the module imports into a `HashSet`, so the sources it writes to `OUT_DIR` are ordered by whatever order the filesystem reports entries in and by hash iteration order. Two checkouts holding identical test files can generate different `integration_tests.rs` and `test_registry.rs`.

* `read_dir` entries are collected into a `Vec<PathBuf>` and sorted before the walk descends.
* The two module-import sets become `BTreeSet`.

Same tests, same count; only the order they are emitted in is now fixed by the directory's contents.

<details>
<summary>Verification</summary>

Compiled the build script from `next` and from this branch, then ran each over two copies of `src/tests` whose entries were created in opposite orders:

| build.rs | identical contents, opposite creation order |
| --- | --- |
| `next` | `integration_tests.rs` and `test_registry.rs` both differ |
| this branch | both byte-identical |

Both versions discover the same 68 tests and the same set of generated test functions, so nothing is gained or lost — `diff` of the sorted function lists is empty. `cargo +nightly fmt --all -- --check` is clean, and clippy reports the same 21 pedantic warnings on the file before and after.
</details>

Split out of #2465, where this was unrelated to that PR's protocol bump.

Reviewers: the only judgement call is sorting `PathBuf`s directly, which orders directories and files together by path rather than visiting files first.
