### PR TITLE
ci: run the publish dry run on next, not just main

### DIFF
--- a/.github/workflows/publish-crates-dry-run.yml
+++ b/.github/workflows/publish-crates-dry-run.yml
@@ -2,9 +2,9 @@ name: Dry Run Publish Rust Crates
 
 on:
   push:
-    branches: [main]
+    branches: [main, next]
   pull_request:
-    branches: [main]
+    branches: [main, next]
 
 permissions:
   contents: read


### PR DESCRIPTION
The publish dry run only gates `main`, so nothing on `next` is ever checked against the publish graph — which is how a release got cut that could not publish.

`miden-client-test-harness` was added to `next` in #2455 as `publish = false`, but referenced through `[workspace.dependencies]` with a `version`. Two published crates reached it: `miden-client-integration-tests` (a normal dependency) and `miden-client-cli` (a versioned dev-dependency). `cargo publish` strips `path` and keeps `version`, so both required a crate that does not exist on the registry.

Nothing caught it until tag time. `v0.16.0-rc.4` was tagged, its publish job failed, and the 0.16 line sat at rc.3 on crates.io for a day while downstream repos waited on it. #2487 fixed the edge and rc.4 published; this closes the gap that let it land.

<details>
<summary>Why this workflow specifically</summary>

The dry run resolves the publish graph without publishing, which is exactly the check that was missing. The 0.16 line is developed on `next` and only reaches `main` at release time — by which point the tag already exists.

It is not a complete net (the dry run does not validate every dependency shape against the registry), but it would have caught this one, at PR time, for free.

</details>

**Reviewers:** the only question worth your time is whether `next` should carry the same publish gate as `main`. If the answer is yes, this is the whole change.
