### PR TITLE
docs: add tonic feature requirement in tutorials

### DIFF
--- a/crates/rust-client/README.md
+++ b/crates/rust-client/README.md
@@ -7,16 +7,20 @@ Rust library, which can be used by other project to programmatically interact wi
 In order to utilize the `miden-client` library, you can add the dependency to your project's `Cargo.toml` file:
 
 ````toml
-miden-client = { version = "0.16.0-alpha.1" }
+miden-client = { version = "0.16.0-alpha.1", features = ["tonic"] }
 ````
+
+Talking to a node requires the `tonic` feature, which is not part of the default set. Leave it out only when supplying your own `NodeRpcClient` and `TransactionProver` implementations.
 
 ## Crate Features
 
 | Features  | Description |
 | --------- | ----------- |
-| `tonic`   | Includes `GrpcClient`, a gRPC client to communicate with a Miden node. Uses `tonic` transport with TLS on native targets and `tonic-web-wasm-client` on `wasm32`. **Disabled by default.** |
-| `std`     | Enables `std` support and concurrent execution in `miden-tx`. Enabled by default for native targets. |
+| `tonic`   | Includes the gRPC pieces that communicate with a Miden node: `GrpcClient`, `RemoteTransactionProver`, the gRPC note transport client, and the `ClientBuilder` methods that wire them up (`for_testnet`, `for_devnet`, `for_localhost`, `grpc_client`). Uses `tonic` transport with TLS on native targets and `tonic-web-wasm-client` on `wasm32`. **Disabled by default.** |
+| `std`     | Enables `std` support and concurrent execution in `miden-tx`. Enabled by default for native targets. It turns on the `tonic` dependency's transport and TLS features, which is not the same as the `tonic` feature above: gRPC support still has to be requested explicitly. |
+| `concurrent` | Enables Rayon-parallel proving in `miden-tx` without the rest of `std`, for `wasm32` consumers that cannot enable it. Native builds get this through `std`. |
 | `testing` | Enables functions meant for testing environments. **Disabled by default.** |
+| `dap`     | Enables running a transaction under a Debug Adapter Protocol client instead of proving it. Implies `std`. **Disabled by default.** |
 
 ### Store and RpcClient implementations
 

--- a/crates/sqlite-store/README.md
+++ b/crates/sqlite-store/README.md
@@ -12,9 +12,12 @@ persistence layer for std environments using SQLite (via `rusqlite`).
 Add to `Cargo.toml`:
 
 ```toml
-miden-client              = { version = "0.16.0-alpha.1" }
+miden-client              = { version = "0.16.0-alpha.1", features = ["tonic"] }
 miden-client-sqlite-store = { version = "0.16.0-alpha.1" }
 ```
+
+The `tonic` feature is what pulls in the gRPC client used to talk to a node. It is not enabled by
+default, so leave it out only when supplying your own `NodeRpcClient` implementation.
 
 ## Migrations
 

--- a/docs/external/src/rust-client/examples.md
+++ b/docs/external/src/rust-client/examples.md
@@ -11,6 +11,8 @@ For a complete example on how to run the client and submit transactions to the M
 
 When using a remote prover, network issues or server errors may cause proving to fail. A common pattern is to configure the client with a remote prover by default and fall back to local proving when remote proving fails.
 
+`RemoteTransactionProver` requires the `tonic` feature (see [Crate features](./features.md#crate-features)).
+
 ```rust
 use std::sync::Arc;
 use miden_client::{

--- a/docs/external/src/rust-client/features.md
+++ b/docs/external/src/rust-client/features.md
@@ -28,3 +28,15 @@ The Miden client supports screening notes against tracked accounts to determine 
 ### Account generation and tracking
 
 The Miden client provides features for generating and tracking accounts within the Miden rollup ecosystem. Users can create accounts and track their transaction status.
+
+### Crate features
+
+The `miden-client` crate gates some of the functionality above behind Cargo features:
+
+| Feature | Description |
+| ------- | ----------- |
+| `tonic` | Includes the gRPC pieces that talk to a node: `GrpcClient`, `RemoteTransactionProver`, the gRPC note transport client, and the `ClientBuilder` methods that wire them up (`for_testnet`, `for_devnet`, `for_localhost`, `grpc_client`). Uses `tonic` transport with TLS on native targets and `tonic-web-wasm-client` on `wasm32`. **Disabled by default.** |
+| `std` | Enables `std` support and concurrent execution in `miden-tx`. Enabled by default for native targets. This turns on the `tonic` dependency's transport and TLS features, which is not the same as the `tonic` feature above: gRPC support still has to be requested explicitly. |
+| `concurrent` | Enables Rayon-parallel proving without pulling in the rest of `std`, for `wasm32` consumers that cannot use it. Native builds get it through `std`. |
+| `testing` | Enables mocks and helpers meant for test environments. **Disabled by default.** |
+| `dap` | Enables running a transaction under a Debug Adapter Protocol client instead of proving it. Implies `std`. **Disabled by default.** |

--- a/docs/external/src/rust-client/library.md
+++ b/docs/external/src/rust-client/library.md
@@ -8,8 +8,10 @@ To use the Miden client library in a Rust project, include it as a dependency.
 In your project's `Cargo.toml`, add:
 
 ```toml
-miden-client = { version = "0.16.0-alpha.1" }
+miden-client = { version = "0.16.0-alpha.1", features = ["tonic"] }
 ```
+
+The `tonic` feature is not enabled by default and gates everything that speaks gRPC to a node: `GrpcClient`, `RemoteTransactionProver`, the gRPC note transport client, and the `ClientBuilder` methods that wire them up. Leave it out only when supplying your own `NodeRpcClient` and `TransactionProver` implementations. See [Features](./features.md#crate-features) for the full list.
 
 ## Client instantiation
 


### PR DESCRIPTION
From #2464

> 1. ClientBuilder::for_testnet() requires non-default tonic feature
ClientBuilder::for_testnet() is gated behind #[cfg(feature = "tonic")]. The standard getting-started docs show ClientBuilder::for_testnet(), but a fresh binary with miden-client = "0.15.5" fails compilation until features = ["tonic"] is added.

Fixes docs by adding explicit requirement of the `tonic` feature when using provided `NodeRpcClient` and `TransactionProver`