### PR TITLE
fix: compare only branch commits for `no migration check`

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           persist-credentials: false
       - name: Check that no released migration was modified

--- a/scripts/check-migrations.sh
+++ b/scripts/check-migrations.sh
@@ -18,8 +18,8 @@ if ! git rev-parse --verify --quiet "${BASE}^{commit}" > /dev/null; then
     exit 1
 fi
 
-# Compared against the merge base rather than the tip of the base branch, so a migration added on
-# the base branch after this one forked is not attributed to this pull request.
+# Compare only the branch's own commits, prevents a migration added on the base branch after this one
+# forked being attributed to this pull request.
 CHANGED=$(git diff --name-only --diff-filter=MDR --merge-base "${BASE}" -- "${MIGRATIONS_DIR}")
 
 if [ -z "${CHANGED}" ]; then


### PR DESCRIPTION
The migrations check ran against the pull request merge ref, so the base branch's own commits were part of `HEAD` and its edits would be attributed to the PR. Checkout now pins the head SHA, so **the diff covers only the branch's commits**.

Closes #2493