### PR TITLE
test: prevent agglayer test flakyness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,14 +140,9 @@ integration-test-non-agglayer: ## Run every integration test except the agglayer
 	TEST_MIDEN_NOTE_TRANSPORT_URL=$(TEST_MIDEN_NOTE_TRANSPORT_URL) MIDEN_FUNDER_ACCOUNTS_DIR=$(MIDEN_FUNDER_ACCOUNTS_DIR) cargo nextest run --workspace --release --test=integration -E 'not test(/agglayer/)'
 	MIDEN_FUNDER_ACCOUNTS_DIR=$(MIDEN_FUNDER_ACCOUNTS_DIR) cargo nextest run --workspace --release --test=integration --run-ignored ignored-only -- import_genesis_accounts_can_be_used_for_transactions
 
-# `agglayer_bridge_in_out` is excluded: its closing B2AGG note produces a network transaction the
-# node cannot prove inside the ntx-builder's deadline, and the builder then retries it for ~15
-# minutes. The test itself passes — it never asserts the note was consumed — but the bridge is
-# occupied throughout, so the agglayer tests that run afterwards never get their notes consumed.
-# TODO: restore once the bridge-out proof fits the deadline, and make the test assert on it.
 .PHONY: integration-test-agglayer
 integration-test-agglayer: ## Run only the agglayer integration tests
-	MIDEN_FUNDER_ACCOUNTS_DIR=$(MIDEN_FUNDER_ACCOUNTS_DIR) AGGLAYER_ACCOUNTS_DIR=$(AGGLAYER_ACCOUNTS_DIR) cargo nextest run --workspace --release --test=integration -E 'test(/agglayer/) - test(=agglayer_bridge_in_out)'
+	MIDEN_FUNDER_ACCOUNTS_DIR=$(MIDEN_FUNDER_ACCOUNTS_DIR) AGGLAYER_ACCOUNTS_DIR=$(AGGLAYER_ACCOUNTS_DIR) cargo nextest run --workspace --release --test=integration -E 'test(/agglayer/)'
 
 .PHONY: integration-test-miden-bench
 integration-test-miden-bench: install-bench ## Run miden-bench smoke tests

--- a/bin/integration-tests/src/tests/agglayer/agglayer_bridge_in_out.rs
+++ b/bin/integration-tests/src/tests/agglayer/agglayer_bridge_in_out.rs
@@ -66,11 +66,6 @@ const TEST_L1_DESTINATION: &str = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd";
 /// Everything but the destination account is pre-deployed and imported (see [`AgglayerConfig`]).
 /// The destination is created fresh on every run, so a claim always targets an account that has
 /// never claimed before.
-///
-/// Excluded from the agglayer CI run, see `make integration-test-agglayer`: the closing B2AGG note
-/// produces a network transaction the node cannot prove inside the ntx-builder's deadline, leaving
-/// the bridge retrying it for ~15 minutes and starving whatever runs next. The bridge-out step
-/// below also asserts nothing, so that failure never surfaces here.
 pub async fn test_agglayer_bridge_in_out(client_config: ClientConfig) -> Result<()> {
     let agglayer_config = AgglayerConfig::from_env()?;
     let _agglayer_accounts = agglayer_config.claim()?;

--- a/scripts/start-test-node.sh
+++ b/scripts/start-test-node.sh
@@ -39,6 +39,11 @@ VALIDATOR="127.0.0.1:50101"
 NTX="127.0.0.1:50301"
 PROVER_PORT=50051
 PROVER="127.0.0.1:$PROVER_PORT"
+# How long a single network transaction proof may take. The prover enforces it server-side and the
+# ntx-builder waits that long for the response. Shared so the two cannot drift apart: if the
+# ntx-builder waited less, it would abandon a request the prover is still working on, re-queue the
+# same proof behind it, and repeat until the note is dropped.
+PROVER_TIMEOUT=300s
 # Shared secret authorizing the ntx-builder to submit network transactions; the sequencer rejects
 # them unless both sides agree on it.
 NETWORK_TX_AUTH="${MIDEN_NETWORK_TX_AUTH:-miden-client-testing-ntx-secret}"
@@ -215,14 +220,17 @@ start sequencer   "$BIN/miden-node" sequencer --rpc.listen "$RPC" --data-directo
     --validator.url "http://$VALIDATOR" --ntx-builder.url "http://$NTX" \
     --rpc.network-tx-auth-header-value "$NETWORK_TX_AUTH" \
     --block.interval 3s --batch.interval 1s
-# A network transaction's proof runs well past the 60s default on a shared CI runner, and the
-# default capacity of 1 rejects the ntx-builder's retry outright, so it never converges.
+# A network transaction's proof runs well past the prover's 60s default on a shared CI runner, and
+# the default capacity of 1 rejects the ntx-builder's retry outright, so it never converges.
 start prover      "$BIN/miden-remote-prover" --kind=transaction --port="$PROVER_PORT" \
-    --timeout 300s --capacity 8
+    --timeout "$PROVER_TIMEOUT" --capacity 8
 # Let the sequencer bind its RPC before the ntx-builder dials it.
 sleep 2
+# The ntx-builder's own default of 10s is shorter than the heaviest proofs take on CI, so it is
+# given the prover's full budget (see PROVER_TIMEOUT).
 start ntx-builder "$BIN/miden-ntx-builder" start --listen "$NTX" --rpc.url "http://$RPC" \
     --rpc.auth-header-value "$NETWORK_TX_AUTH" --tx-prover.url "http://$PROVER" \
+    --tx-prover.timeout "$PROVER_TIMEOUT" \
     --max-cycles "$((1 << 18))" \
     --data-directory "$DATA/ntx-builder"
 


### PR DESCRIPTION
Increase ntx builder timeout (to wait for a proven transaction) to match the remote prover's. previously it was kept on the default of 10s, making it fail.

Closes #2440