### PR TITLE
chore: pass `Into<NoteRecipient>` to `expected_output_recipients`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@
 * [FEATURE][cli] `call` now works on public accounts that aren't tracked locally: the account is read from the network via a foreign procedure invocation, run from one of the client's own accounts (the default account when set). Such calls are read-only, so no state delta is shown. `--package` (`-p`) is now optional; if not set, `<PROCEDURE>` must be a hex digest and the output stack is printed as raw felts ([#2187](https://github.com/0xMiden/rust-sdk/pull/2187)).
 * [rust] `Client::execute_transaction`, `Client::execute_transaction_with_dap`, `Client::execute_program`, `Client::execute_program_with_dap`, `Client::set_setting` and `Client::remove_setting` now take `&self` instead of `&mut self`; none of them mutate the client ([#2187](https://github.com/0xMiden/rust-sdk/pull/2187)).
 * [store] Each SQL migration now carries the fingerprint of the schema it builds. Opening a store checks every version it applies against that version's own pin, so a migration edited to build a different schema is rejected even when creating a fresh database ([#2445](https://github.com/0xMiden/rust-sdk/pull/2445)).
+* [FEATURE][rust] `TransactionRequestBuilder::expected_output_recipients` now takes any `IntoIterator` whose items convert into `NoteRecipient`, matching `own_output_notes` and `foreign_accounts`, so recipients no longer have to be collected into a `Vec<NoteRecipient>` first. Callers already passing a `Vec<NoteRecipient>` are unaffected ([#2499](https://github.com/0xMiden/rust-sdk/pull/2499)).
 
 ### Fixes
 

--- a/crates/rust-client/src/transaction/request/builder.rs
+++ b/crates/rust-client/src/transaction/request/builder.rs
@@ -197,10 +197,16 @@ impl TransactionRequestBuilder {
     /// specified expected recipients, but it may also create notes for other recipients not
     /// included in this set.
     #[must_use]
-    pub fn expected_output_recipients(mut self, recipients: Vec<NoteRecipient>) -> Self {
+    pub fn expected_output_recipients(
+        mut self,
+        recipients: impl IntoIterator<Item = impl Into<NoteRecipient>>,
+    ) -> Self {
         self.expected_output_recipients = recipients
             .into_iter()
-            .map(|recipient| (recipient.digest(), recipient))
+            .map(|recipient| {
+                let recipient: NoteRecipient = recipient.into();
+                (recipient.digest(), recipient)
+            })
             .collect::<BTreeMap<_, _>>();
         self
     }


### PR DESCRIPTION
Refactor `TransactionRequestBuilder::expected_output_recipient` so it now takes `IntoIterator<Item = impl Into<NoteRecipient>>` instead of `Vec<NoteRecipient>`, aligning with sibling methods (`own_output_notes`/`foreign_accounts`).

Closes #1113