### PR TITLE
fix(sync): return error instead of panicking on get_account proof with no details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@
 ### Fixes
 
 * [FIX][cli] `miden-client import` now rejects invocations without a file path instead of silently succeeding ([#2450](https://github.com/0xMiden/rust-sdk/pull/2450)).
-<!-- TODO: update the PR link below to the actual PR number once the PR is opened (currently a placeholder). -->
-* [FIX][rust] `StateSync::validate_account_proof` now returns a `ChainValidationError` when a `get_account` proof carries no account details, instead of panicking. The RPC layer allows the details to be absent, so a malformed or malicious node response could crash the client mid-sync ([#XXXX](https://github.com/0xMiden/rust-sdk/pull/XXXX)).
+* [FIX][rust] `StateSync::validate_account_proof` now returns a `ChainValidationError` when a `get_account` proof carries no account details, instead of panicking. The RPC layer allows the details to be absent, so a malformed or malicious node response could crash the client mid-sync ([#2502](https://github.com/0xMiden/rust-sdk/pull/2502)).
 
 ## 0.16.0 (2026-09-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixes
 
 * [FIX][cli] `miden-client import` now rejects invocations without a file path instead of silently succeeding ([#2450](https://github.com/0xMiden/rust-sdk/pull/2450)).
-* [FIX][rust] `StateSync::validate_account_proof` now returns a `ChainValidationError` when a `get_account` proof carries no account details, instead of panicking. The RPC layer allows the details to be absent, so a malformed or malicious node response could crash the client mid-sync ([#2502](https://github.com/0xMiden/rust-sdk/pull/2502)).
+* [FIX][rust] Public account sync now returns `RpcError::ExpectedDataMissing` instead of panicking when a `get_account` response carries no account details ([#2502](https://github.com/0xMiden/rust-sdk/pull/2502)).
 * [FIX][rust] `TransactionRequestBuilder::build_swap` and `build_pswap_create` now reject a zero-amount asset on either side of the exchange. A zero requested asset produced a payback P2ID note carrying nothing, and a zero offered asset produced a note whose consumer pays and receives nothing ([#2459](https://github.com/0xMiden/rust-sdk/pull/2459)).
 
 ## 0.16.0 (2026-09-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixes
 
 * [FIX][cli] `miden-client import` now rejects invocations without a file path instead of silently succeeding ([#2450](https://github.com/0xMiden/rust-sdk/pull/2450)).
+<!-- TODO: update the PR link below to the actual PR number once the PR is opened (currently a placeholder). -->
+* [FIX][rust] `StateSync::validate_account_proof` now returns a `ChainValidationError` when a `get_account` proof carries no account details, instead of panicking. The RPC layer allows the details to be absent, so a malformed or malicious node response could crash the client mid-sync ([#XXXX](https://github.com/0xMiden/rust-sdk/pull/XXXX)).
 
 ## 0.16.0 (2026-09-07)
 

--- a/crates/rust-client/src/sync/state_sync.rs
+++ b/crates/rust-client/src/sync/state_sync.rs
@@ -1062,9 +1062,9 @@ impl StateSync {
     /// - the proof is for a different block than the sync target.
     /// - the witness is for a different account than the requested one.
     /// - the witness does not open under the sync target header's account root.
-    /// - the proof carries no account details. This is only called for public accounts, for which
-    ///   the node is expected to return details, but a malformed or malicious response can omit
-    ///   them, so it is rejected rather than trusted as an invariant.
+    ///
+    /// Returns [`ClientError::RpcError`] if the proof carries no account details. The node returns
+    /// details for every public account, so a missing value means the response is malformed.
     fn validate_account_proof(
         proof: AccountProof,
         proof_block_num: BlockNumber,
@@ -1102,9 +1102,9 @@ impl StateSync {
             })?;
 
         details.ok_or_else(|| {
-            ClientError::ChainValidationError(format!(
+            ClientError::RpcError(RpcError::ExpectedDataMissing(format!(
                 "get_account returned no details for public account {account_id}"
-            ))
+            )))
         })
     }
 
@@ -1822,8 +1822,7 @@ mod tests {
         assert!(matches!(result, Err(ClientError::ChainValidationError(_))));
     }
 
-    /// `validate_account_proof` rejects a proof that carries no account details rather than
-    /// panicking, since a malformed or malicious node response can omit them.
+    /// `validate_account_proof` rejects a proof that carries no account details.
     #[tokio::test]
     async fn validate_account_proof_rejects_missing_details() {
         let mut builder = MockChainBuilder::new();
@@ -1833,7 +1832,7 @@ mod tests {
 
         // An otherwise honest proof, but with the account details stripped.
         let (proof_block_num, proof) = get_account_proof(&rpc_api, account.id()).await;
-        let (witness, _details) = proof.into_parts();
+        let (witness, _) = proof.into_parts();
         let proof = AccountProof::new(witness, None).unwrap();
         let result = StateSync::validate_account_proof(
             proof,
@@ -1842,7 +1841,7 @@ mod tests {
             &chain_tip_header,
         );
 
-        assert!(matches!(result, Err(ClientError::ChainValidationError(_))));
+        assert!(matches!(result, Err(ClientError::RpcError(RpcError::ExpectedDataMissing(_)))));
     }
 
     /// `validate_account_proof` rejects a proof reported for a block other than the sync target.

--- a/crates/rust-client/src/sync/state_sync.rs
+++ b/crates/rust-client/src/sync/state_sync.rs
@@ -988,11 +988,6 @@ impl StateSync {
     ///
     /// Must only be called when the local commitment for the account is known to differ from the
     /// network's, so an equal nonce always means a genuine fork.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the node response omits account details, since that would mean the account is not
-    /// public.
     async fn sync_public_account(
         &self,
         account_id: AccountId,
@@ -1067,11 +1062,9 @@ impl StateSync {
     /// - the proof is for a different block than the sync target.
     /// - the witness is for a different account than the requested one.
     /// - the witness does not open under the sync target header's account root.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the proof carries no account details, since this is only called for public
-    /// accounts and the node always returns details for them.
+    /// - the proof carries no account details. This is only called for public accounts, for which
+    ///   the node is expected to return details, but a malformed or malicious response can omit
+    ///   them, so it is rejected rather than trusted as an invariant.
     fn validate_account_proof(
         proof: AccountProof,
         proof_block_num: BlockNumber,
@@ -1108,7 +1101,11 @@ impl StateSync {
                 ))
             })?;
 
-        Ok(details.expect("node returned no details for a public account"))
+        details.ok_or_else(|| {
+            ClientError::ChainValidationError(format!(
+                "get_account returned no details for public account {account_id}"
+            ))
+        })
     }
 
     /// Builds a [`PublicAccountUpdate::Patch`] by fetching incremental storage map and vault
@@ -1821,6 +1818,29 @@ mod tests {
         let (proof_block_num, proof) = get_account_proof(&rpc_api, account.id()).await;
         let result =
             StateSync::validate_account_proof(proof, proof_block_num, account.id(), &wrong_header);
+
+        assert!(matches!(result, Err(ClientError::ChainValidationError(_))));
+    }
+
+    /// `validate_account_proof` rejects a proof that carries no account details rather than
+    /// panicking, since a malformed or malicious node response can omit them.
+    #[tokio::test]
+    async fn validate_account_proof_rejects_missing_details() {
+        let mut builder = MockChainBuilder::new();
+        let account = builder.add_existing_mock_account(miden_testing::Auth::IncrNonce).unwrap();
+        let rpc_api = MockRpcApi::new(builder.build().unwrap());
+        let chain_tip_header = rpc_api.mock_chain.read().latest_block_header();
+
+        // An otherwise honest proof, but with the account details stripped.
+        let (proof_block_num, proof) = get_account_proof(&rpc_api, account.id()).await;
+        let (witness, _details) = proof.into_parts();
+        let proof = AccountProof::new(witness, None).unwrap();
+        let result = StateSync::validate_account_proof(
+            proof,
+            proof_block_num,
+            account.id(),
+            &chain_tip_header,
+        );
 
         assert!(matches!(result, Err(ClientError::ChainValidationError(_))));
     }


### PR DESCRIPTION
## Summary

`StateSync::validate_account_proof` unwrapped the optional account details from a `get_account` proof with `.expect("node returned no details for a public account")`, treating their presence as an invariant. But `AccountProof` allows `details: None` end-to-end — the RPC conversion layer in `rpc/domain/account.rs` produces `None` when the response omits them — so a malformed, buggy, or malicious node response crashes the client with a panic mid-sync instead of surfacing a validation error.

This is the same class of untrusted-input hardening as the recent `VerifyingRpcClient` fixes (#2419, #2381): a value the node controls was trusted without being checked.

## The bug

`crates/rust-client/src/sync/state_sync.rs`

```rust
Ok(details.expect("node returned no details for a public account"))
```

Reachable during public account sync: the proof reaches `validate_account_proof`, passes the block / account-id / witness checks, then panics on the final `.expect()` if `details` is `None`.

## The fix

Return `ClientError::ChainValidationError` when details are absent, consistent with the function's other validation failures:

```rust
details.ok_or_else(|| {
    ClientError::ChainValidationError(format!(
        "get_account returned no details for public account {account_id}"
    ))
})
```

The `# Panics` doc section is replaced with a fourth `# Errors` bullet, and a regression test (`validate_account_proof_rejects_missing_details`) builds an otherwise-honest proof with the details stripped and asserts `ChainValidationError`.

## Verification

- `make lint` — clean (`cargo fix`, `cargo +nightly fmt`, `taplo fmt`, `cargo clippy --workspace --features "testing std" --all-targets -- -D warnings`, `cargo shear` all pass, no warnings)
- `make test` — **458 tests run: 458 passed, 2 skipped**; the new regression test passes

Closes #2386
