### PR TITLE
docs(changelog): fix typo "integraion" -> "integration"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -656,7 +656,7 @@
 ### Fixes
 
 * Added JS files generated from TypeScript ([#1218](https://github.com/0xMiden/rust-sdk/pull/1218)).
-* Changed method for automatically picking up tests for integraion tests binary ([#1219](https://github.com/0xMiden/rust-sdk/pull/1219)).
+* Changed method for automatically picking up tests for integration tests binary ([#1219](https://github.com/0xMiden/rust-sdk/pull/1219)).
 
 ## 0.11.0 (2025-08-30)
 


### PR DESCRIPTION
  ## Description
  Fixes a single spelling mistake in an old CHANGELOG.md entry: "integraion" → "integration".

  Found by running the repo's own `typos` linter (crate-ci/typos v1.50.1) against
  `.typos.toml` — it currently flags this as the only typo in the repository.

  ## Pre-PR checklist
  - [x] Branch forked from `next`, kebab-case name
  - [x] Commit message follows semantic commit convention
  - [x] No code/behavior change — cosmetic fix only, no CHANGELOG entry needed per
        CONTRIBUTING.md ("Internal refactors or smaller tweaks that don't affect
        public behaviour can be left out")
  - [x] `make typos-check` passes locally with this change