### PR TITLE
chore: prepare `0.16` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@
 * [BREAKING][behavior][rust] `Client::list_setting_keys` returns only the user's keys. The client's own entries, such as the note transport cursor and the cached RPC limits, no longer appear in the listing and can no longer be read or overwritten through the `Client` settings API ([#2456](https://github.com/0xMiden/rust-sdk/pull/2456)).
 * [BREAKING][behavior][store] The SQLite `settings` table now carries a `scope` column with `(scope, name)` as its primary key. This changes the schema fingerprint, so opening a database created before this change fails with `SchemaDrift` and existing stores must be recreated ([#2456](https://github.com/0xMiden/rust-sdk/pull/2456)).
 
-* [BREAKING][rust] Updated the protocol dependencies to `0.16.0-rc.9`, which raises the MSRV to 1.98. `guarded_multisig.masm` and `multisig_smart.masm` both call `fee::load_conversion_info` as of that release, so `AuthMultisigSmart` now reads the auth argument as fee conversion info rather than as a summary salt alone and, like the other multisig components, must declare its own salt on a fee-charging chain ([#2465](https://github.com/0xMiden/rust-sdk/pull/2465)).
+* [BREAKING][rust] Updated the protocol dependencies to `0.16.1`, which raises the MSRV to 1.98.1. `guarded_multisig.masm` and `multisig_smart.masm` both call `fee::load_conversion_info` as of `0.16.0-rc.9`, so `AuthMultisigSmart` now reads the auth argument as fee conversion info rather than as a summary salt alone and, like the other multisig components, must declare its own salt on a fee-charging chain ([#2465](https://github.com/0xMiden/rust-sdk/pull/2465)).
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -656,7 +656,7 @@
 ### Fixes
 
 * Added JS files generated from TypeScript ([#1218](https://github.com/0xMiden/rust-sdk/pull/1218)).
-* Changed method for automatically picking up tests for integraion tests binary ([#1219](https://github.com/0xMiden/rust-sdk/pull/1219)).
+* Changed method for automatically picking up tests for integration tests binary ([#1219](https://github.com/0xMiden/rust-sdk/pull/1219)).
 
 ## 0.11.0 (2025-08-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.16.0 (2026-09-07)
 
 ### Breaking Changes
 
@@ -46,7 +46,7 @@
 * [BREAKING][behavior][rust] `Client::list_setting_keys` returns only the user's keys. The client's own entries, such as the note transport cursor and the cached RPC limits, no longer appear in the listing and can no longer be read or overwritten through the `Client` settings API ([#2456](https://github.com/0xMiden/rust-sdk/pull/2456)).
 * [BREAKING][behavior][store] The SQLite `settings` table now carries a `scope` column with `(scope, name)` as its primary key. This changes the schema fingerprint, so opening a database created before this change fails with `SchemaDrift` and existing stores must be recreated ([#2456](https://github.com/0xMiden/rust-sdk/pull/2456)).
 
-* [BREAKING][rust] Updated the protocol dependencies to `0.16.1`, which raises the MSRV to 1.98.1. `guarded_multisig.masm` and `multisig_smart.masm` both call `fee::load_conversion_info` as of `0.16.0-rc.9`, so `AuthMultisigSmart` now reads the auth argument as fee conversion info rather than as a summary salt alone and, like the other multisig components, must declare its own salt on a fee-charging chain ([#2465](https://github.com/0xMiden/rust-sdk/pull/2465)).
+* [BREAKING][rust] Updated the protocol dependencies to `0.16.1`, which raises the MSRV to 1.98.1. `guarded_multisig.masm` and `multisig_smart.masm` both call `fee::load_conversion_info` as of `0.16.0-rc.9`, so `AuthMultisigSmart` now reads the auth argument as fee conversion info rather than as a summary salt alone and, like the other multisig components, must declare its own salt on a fee-charging chain ([#2465](https://github.com/0xMiden/rust-sdk/pull/2465), [#2511](https://github.com/0xMiden/rust-sdk/pull/2511)).
 
 ### Fixes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ make install-tools
 ## Code Style
 
 ### Rust
-- Edition 2024, MSRV 1.98
+- Edition 2024, MSRV 1.98.1
 - Use section headers for major code sections:
   ```rust
   // SECTION NAME

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client"
-version = "0.16.0-rc.5"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2613,7 +2613,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-bench"
-version = "0.16.0-rc.5"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2630,7 +2630,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-cli"
-version = "0.16.0-rc.5"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2659,7 +2659,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-integration-tests"
-version = "0.16.0-rc.5"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2683,7 +2683,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-sqlite-store"
-version = "0.16.0-rc.5"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "miden-client-unit-tests"
-version = "0.16.0-rc.5"
+version = "0.16.0"
 dependencies = [
  "miden-client",
  "miden-client-sqlite-store",
@@ -5362,7 +5362,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-node-genesis"
-version = "0.16.0-rc.5"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "miden-agglayer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3036,9 +3036,9 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto-build"
-version = "0.16.0-rc.5"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be898c22d3f1f398658925cb31d18871c239cc9b7004ee3d8099d74efc70e1e6"
+checksum = "724a79e7663157e73de1fc19fcd6e30c7cee4e4c4189d44477922a3969797acb"
 dependencies = [
  "build-rs",
  "codegen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "proc-macro-error3",
  "proc-macro2",
  "quote",
@@ -483,7 +483,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -638,7 +638,7 @@ dependencies = [
  "prettyplease 0.3.0",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -807,7 +807,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -828,7 +828,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "573800db6c3319bc125ddbf9b9cb001ad1602957f53642ba8d09ff3ddd4da7f1"
 dependencies = [
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
 ]
 
 [[package]]
@@ -964,9 +964,9 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+checksum = "622f3fc73690be383c7214310406f28a90e6edeadc3cea882f9d71e495b9711a"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -974,18 +974,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.20"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+checksum = "dc74980687109a3b14c72fd458107bf0baa1da1a1a805e178d15501ba9b86d9d"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+checksum = "a31eee39dddec8330830986fcd7625edb5a24ec90ea038215273bbc3adb08ac6"
 
 [[package]]
 name = "crossterm"
@@ -1108,7 +1108,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1119,7 +1119,7 @@ checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
 dependencies = [
  "darling_core",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1185,9 +1185,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+checksum = "a878c850e9e421b20262e9b41f9c860e4785fa07541c266b62ff9d1ef998a80a"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -1416,7 +1416,7 @@ checksum = "a65863d15a4ce2888bd2f0f543cc963d3879c3a022c8ee43f6141d479a3ac815"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1680,7 +1680,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1829,7 +1829,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "slab",
  "tokio",
  "tokio-util",
@@ -2085,9 +2085,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.1"
+version = "2.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
+checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -2238,9 +2238,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2470,9 +2470,9 @@ dependencies = [
 
 [[package]]
 name = "miden-agglayer"
-version = "0.16.0-rc.9"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69316dfc0c3d880aa328b6b13550c606ed607a5bc367a69b61c2f0303384b20e"
+checksum = "c9340d981c2aaefded2a28ca66f10169dd4170c912538d33fe8690ea549e468e"
 dependencies = [
  "alloy-sol-types",
  "fs-err",
@@ -2562,9 +2562,9 @@ dependencies = [
 
 [[package]]
 name = "miden-block-prover"
-version = "0.16.0-rc.9"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6039840fa65549acced4c65f9d2e3e938016b6ec2df2b608543e1eeee14d71"
+checksum = "3e34859c5f2005e95cfc5ba97ae0dffec15bb44460fc23262532e5e2aee49155"
 dependencies = [
  "miden-protocol",
  "thiserror",
@@ -3148,9 +3148,9 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol"
-version = "0.16.0-rc.9"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d0e83b841c75cababe1a9622872c71b693888e206574985aab67b24fcdb0bf"
+checksum = "89ccf181d3a4e90b9e6ac107547ce1db30f085dfe5696a7735b1de03ac02f6ba"
 dependencies = [
  "bech32",
  "fs-err",
@@ -3179,9 +3179,9 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol-build-utils"
-version = "0.16.0-rc.9"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e115c3886d07558c4ea0a375c84dbc233afff9d4cd8157d9470d2e95594f084"
+checksum = "9d16cdd96c1d0b3b2d57342d37eaadd15cc7c633bda965fc8c3b23ca249965b4"
 dependencies = [
  "fs-err",
  "miden-assembly",
@@ -3232,9 +3232,9 @@ dependencies = [
 
 [[package]]
 name = "miden-standards"
-version = "0.16.0-rc.9"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f448c316cf5b1e3fe06374fd17f71af7b75b91e730695c37b17bf70a018f5178"
+checksum = "ee6fc2cdac6d1bb48ae4b0c2f0498e754490750283783b7a71b25c3017e68754"
 dependencies = [
  "bon",
  "miden-assembly",
@@ -3271,9 +3271,9 @@ dependencies = [
 
 [[package]]
 name = "miden-testing"
-version = "0.16.0-rc.9"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b8ca42ab5ce2359a1e6f9f502fc24c6832816b11b9f782a6b1f2473a58ff2a"
+checksum = "697ea989c4553c1676dd740e41ad29d35fa6b1ac2ab20893c647fa4c7ec6d9dd"
 dependencies = [
  "anyhow",
  "itertools 0.15.0",
@@ -3292,9 +3292,9 @@ dependencies = [
 
 [[package]]
 name = "miden-tx"
-version = "0.16.0-rc.9"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d6e37711034331959d11e66d5abf96a8cab07a40b94bed735b5d062e2cb841"
+checksum = "6d5e8e69cf0db2d2f37f16909fc17d0b28730e1d21a587580ec90f27e19e309f"
 dependencies = [
  "bon",
  "miden-agglayer",
@@ -3307,9 +3307,9 @@ dependencies = [
 
 [[package]]
 name = "miden-tx-batch"
-version = "0.16.0-rc.9"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92f7b08f6ee27fbd656ac8c3ff22bc77e735c46b2907d35d38492425ca09f16a"
+checksum = "06419d4c747d8e79674d2be1436f0a46abe70aa2598f1789e71a07c14106cfa9"
 dependencies = [
  "miden-processor",
  "miden-protocol",
@@ -3909,9 +3909,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
+checksum = "6d45aeb61b4bf818e12d4205f2466f8c4748f85f4fce0146d1c03d69d753f0ad"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -3925,7 +3925,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
 ]
 
 [[package]]
@@ -4057,7 +4057,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bfe0f4c752e450fc2faf62654f1c134747922825d5b04ca717b8874f41a40c0"
 dependencies = [
  "proc-macro2",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -4114,7 +4114,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93980406f12d9f8140ed5abe7155acb10bb1e69ea55c88960b9c2f117445ef96"
 dependencies = [
  "equivalent",
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "serde",
 ]
 
@@ -4295,7 +4295,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f5df7e552bc7edd075f5783a87fbfc21d6a546e32c16985679c488c18192d83"
 dependencies = [
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "log",
  "priority-queue",
  "rustc-hash",
@@ -4520,7 +4520,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -4741,9 +4741,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.43"
+version = "0.23.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+checksum = "6725596c3f2c3a0aef021139e145d4eafe314a6623e4680ca83852b2c67ab2ba"
 dependencies = [
  "log",
  "once_cell",
@@ -4982,7 +4982,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -5006,7 +5006,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -5038,7 +5038,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "jiff",
  "schemars 0.9.0",
  "schemars 1.2.2",
@@ -5277,9 +5277,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5402,7 +5402,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -5491,7 +5491,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -5548,7 +5548,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -5563,7 +5563,7 @@ version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -5605,7 +5605,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -5619,7 +5619,7 @@ version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.4",
@@ -5761,7 +5761,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.14.1",
+ "indexmap 2.14.2",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -6094,9 +6094,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6107,9 +6107,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.77"
+version = "0.4.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
+checksum = "6ef4c5d3d2cdf5c54f4231181768f5510842e350db025faf1f7163b1030ed928"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6117,9 +6117,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6127,22 +6127,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
 dependencies = [
  "unicode-ident",
 ]
@@ -6162,9 +6162,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+checksum = "9fbddc4a036f00ec4f18c83445bd3115cb306a91da554919a099d9222fe4a7f8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ authors      = ["miden contributors"]
 edition      = "2024"
 license      = "MIT"
 repository   = "https://github.com/0xMiden/rust-sdk"
-rust-version = "1.98"
+rust-version = "1.98.1"
 version      = "0.16.0-rc.5"
 
 [profile.dev]
@@ -41,22 +41,22 @@ miden-client-integration-tests = { default-features = false, path = "bin/integra
 miden-client-sqlite-store      = { default-features = false, path = "crates/sqlite-store", version = "0.16.0-rc.5" }
 
 # Miden protocol dependencies
-miden-agglayer  = { default-features = false, version = "0.16.0-rc.9" }
-miden-protocol  = { default-features = false, version = "0.16.0-rc.9" }
-miden-standards = { default-features = false, version = "0.16.0-rc.9" }
-miden-testing   = { default-features = false, version = "0.16.0-rc.9" }
-miden-tx        = { default-features = false, version = "0.16.0-rc.9" }
-miden-tx-batch  = { default-features = false, version = "0.16.0-rc.9" }
+miden-agglayer  = { default-features = false, version = "0.16" }
+miden-protocol  = { default-features = false, version = "0.16" }
+miden-standards = { default-features = false, version = "0.16" }
+miden-testing   = { default-features = false, version = "0.16" }
+miden-tx        = { default-features = false, version = "0.16" }
+miden-tx-batch  = { default-features = false, version = "0.16" }
 
 # Miden node dependencies
 miden-node-proto-build           = { default-features = false, version = "0.16.0-rc.5" }
 miden-note-transport-proto-build = { default-features = false, version = "0.5.0-alpha.1" }
 
 # Miden debug dependency
-miden-assembly-syntax = { default-features = false, version = "0.29.2" }
+miden-assembly-syntax = { default-features = false, version = "0.29" }
 miden-debug           = { default-features = false, features = ["dap", "std"], version = "0.10" }
-miden-mast-package    = { default-features = false, version = "0.29.2" }
-miden-processor       = { default-features = false, version = "0.29.2" }
+miden-mast-package    = { default-features = false, version = "0.29" }
+miden-processor       = { default-features = false, version = "0.29" }
 
 # External dependencies
 anyhow             = { default-features = false, version = "1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,9 @@ opt-level = 1
 
 [workspace.dependencies]
 # Workspace crates
-miden-client                   = { default-features = false, path = "crates/rust-client", version = "0.16.0" }
-miden-client-integration-tests = { default-features = false, path = "bin/integration-tests", version = "0.16.0" }
-miden-client-sqlite-store      = { default-features = false, path = "crates/sqlite-store", version = "0.16.0" }
+miden-client                   = { default-features = false, path = "crates/rust-client", version = "0.16" }
+miden-client-integration-tests = { default-features = false, path = "bin/integration-tests", version = "0.16" }
+miden-client-sqlite-store      = { default-features = false, path = "crates/sqlite-store", version = "0.16" }
 
 # Miden protocol dependencies
 miden-agglayer  = { default-features = false, version = "0.16" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ edition      = "2024"
 license      = "MIT"
 repository   = "https://github.com/0xMiden/rust-sdk"
 rust-version = "1.98.1"
-version      = "0.16.0-rc.5"
+version      = "0.16.0"
 
 [profile.dev]
 codegen-units = 16
@@ -36,9 +36,9 @@ opt-level = 1
 
 [workspace.dependencies]
 # Workspace crates
-miden-client                   = { default-features = false, path = "crates/rust-client", version = "0.16.0-rc.5" }
-miden-client-integration-tests = { default-features = false, path = "bin/integration-tests", version = "0.16.0-rc.5" }
-miden-client-sqlite-store      = { default-features = false, path = "crates/sqlite-store", version = "0.16.0-rc.5" }
+miden-client                   = { default-features = false, path = "crates/rust-client", version = "0.16.0" }
+miden-client-integration-tests = { default-features = false, path = "bin/integration-tests", version = "0.16.0" }
+miden-client-sqlite-store      = { default-features = false, path = "crates/sqlite-store", version = "0.16.0" }
 
 # Miden protocol dependencies
 miden-agglayer  = { default-features = false, version = "0.16" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,8 @@ miden-tx        = { default-features = false, version = "0.16" }
 miden-tx-batch  = { default-features = false, version = "0.16" }
 
 # Miden node dependencies
-miden-node-proto-build           = { default-features = false, version = "0.16.0-rc.5" }
-miden-note-transport-proto-build = { default-features = false, version = "0.5.0-alpha.1" }
+miden-node-proto-build           = { default-features = false, version = "0.16" }
+miden-note-transport-proto-build = { default-features = false, version = "0.5.0-rc.2" }
 
 # Miden debug dependency
 miden-assembly-syntax = { default-features = false, version = "0.29" }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/0xMiden/rust-sdk/blob/HEAD/LICENSE)
 [![test](https://github.com/0xMiden/rust-sdk/actions/workflows/test.yml/badge.svg)](https://github.com/0xMiden/rust-sdk/actions/workflows/test.yml)
 [![build](https://github.com/0xMiden/rust-sdk/actions/workflows/build.yml/badge.svg)](https://github.com/0xMiden/rust-sdk/actions/workflows/build.yml)
-[![RUST_VERSION](https://img.shields.io/badge/rustc-1.98+-lightgray.svg)](https://www.rust-lang.org/tools/install)
+[![RUST_VERSION](https://img.shields.io/badge/rustc-1.98.1+-lightgray.svg)](https://www.rust-lang.org/tools/install)
 [![crates.io](https://img.shields.io/crates/v/miden-client)](https://crates.io/crates/miden-client)
 
 This repository contains the Miden client, which provides a way to execute and prove transactions, facilitating the interaction with the Miden rollup.

--- a/bin/miden-cli/README.md
+++ b/bin/miden-cli/README.md
@@ -4,7 +4,7 @@ This binary allows the user to interact with the Miden rollup via a simple comma
 
 ## Usage
 
-Before you can use the Miden client, you'll need to make sure you have [Rust](https://www.rust-lang.org/tools/install) installed. Miden client requires rust version **1.98** or higher.
+Before you can use the Miden client, you'll need to make sure you have [Rust](https://www.rust-lang.org/tools/install) installed. Miden client requires rust version **1.98.1** or higher.
 
 ### Running `miden-client`'s CLI
 

--- a/docs/external/src/rust-client/install-and-run.md
+++ b/docs/external/src/rust-client/install-and-run.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 
 ## Software prerequisites
 
-- [Rust installation](https://www.rust-lang.org/tools/install) minimum version 1.98.
+- [Rust installation](https://www.rust-lang.org/tools/install) minimum version 1.98.1.
 
 ## Install the client
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel    = "1.98"
+channel    = "1.98.1"
 components = ["clippy", "rust-src", "rustfmt"]
 profile    = "minimal"


### PR DESCRIPTION
- Upgrades Miden crates to 0.16
  - Upgrades MSRV to 1.98.1 as required by the new protocol crates
- Fixes small typo in changelog
- Updates the unreleased section of the changelog to reflect 0.16's release
- Bunmps client crate versions to 0.16