### PR TITLE
feat(miden-client): re-export NetworkNotePricer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [FIX][cli] `miden-client import` now rejects invocations without a file path instead of silently succeeding ([#2450](https://github.com/0xMiden/rust-sdk/pull/2450)).
 
+### Enhancements
+
+* [rust] Re-exported `NetworkNotePricer` from `miden_client`, allowing downstream users to avoid a direct `miden-tx` dependency ([#2517](https://github.com/0xMiden/rust-sdk/issues/2517)).
+
 ## 0.16.0 (2026-09-07)
 
 ### Breaking Changes

--- a/crates/rust-client/src/lib.rs
+++ b/crates/rust-client/src/lib.rs
@@ -344,7 +344,7 @@ pub use miden_protocol::{
     Word,
     ZERO,
 };
-pub use miden_tx::ExecutionOptions;
+pub use miden_tx::{ExecutionOptions, NetworkNotePricer};
 #[cfg(feature = "tonic")]
 pub use remote_prover::RemoteTransactionProver;
 


### PR DESCRIPTION
Closes #2517.

## Summary
- re-export `NetworkNotePricer` from the `miden_client` crate root alongside `ExecutionOptions`
- document the new downstream-visible API in the unreleased changelog
- allow consumers such as `miden-faucet` to remove their direct `miden-tx` dependency

## Validation
- confirmed `NetworkNotePricer` is a public root export of the pinned `miden-tx` dependency
- `git diff --check` passed
- the available runner does not include Cargo, so hosted CI is the compile/lint gate

## Scope check
Immediately before submission, issue comments, open and recently merged PRs, upstream branches, and recent commits were checked. No overlapping implementation was found.