### PR TITLE
feat(rust-client): re-export fee pricing and note checker types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+* [FEATURE][rust] Re-exported the fee pricing and note checking types that the client API already surfaces, so downstream crates no longer need a direct `miden-tx` dependency to price note consumption: `NetworkNotePricer`, `NotePricingError` and `NoteCheckerError` at the crate root, `TransactionFee` and `TransactionFeeError` from `transaction`, `NoteCost` and `NoteConsumptionCost` from `note`, and `MastForestStore` and `TransactionMastStore` from `testing` ([#2475](https://github.com/0xMiden/rust-sdk/pull/2475)).
+
 ### Fixes
 
 * [FIX][cli] `miden-client import` now rejects invocations without a file path instead of silently succeeding ([#2450](https://github.com/0xMiden/rust-sdk/pull/2450)).

--- a/crates/rust-client/src/errors.rs
+++ b/crates/rust-client/src/errors.rs
@@ -29,8 +29,8 @@ pub use miden_standards::errors::CodeBuilderError;
 use miden_standards::tx_script::SendNotesTransactionScriptError;
 use miden_tx::utils::HexParseError;
 use miden_tx::utils::serde::DeserializationError;
-pub use miden_tx::{AuthenticationError, TransactionExecutorError};
-use miden_tx::{DataStoreError, NoteCheckerError, TransactionProverError};
+pub use miden_tx::{AuthenticationError, NoteCheckerError, TransactionExecutorError};
+use miden_tx::{DataStoreError, TransactionProverError};
 use thiserror::Error;
 
 use crate::note::NoteScreenerError;

--- a/crates/rust-client/src/lib.rs
+++ b/crates/rust-client/src/lib.rs
@@ -344,7 +344,7 @@ pub use miden_protocol::{
     Word,
     ZERO,
 };
-pub use miden_tx::{ExecutionOptions, NetworkNotePricer};
+pub use miden_tx::{ExecutionOptions, NetworkNotePricer, NotePricingError};
 #[cfg(feature = "tonic")]
 pub use remote_prover::RemoteTransactionProver;
 
@@ -357,10 +357,10 @@ pub mod testing {
     pub use miden_standards::testing as standards;
     pub use miden_standards::testing::note::NoteBuilder;
     pub use miden_testing::*;
-    /// The data store the executor reads from, along with the trait whose methods it serves.
-    /// Exposed here so that tests can exercise it on its own, without going through a transaction
-    /// or a note screening pass.
-    pub use miden_tx::DataStore;
+    /// The data store the executor reads from, the MAST forest store trait it also serves, and the
+    /// MAST store that [`ClientDataStore::mast_store`] returns. Exposed here so that tests can
+    /// exercise them on their own, without going through a transaction or a note screening pass.
+    pub use miden_tx::{DataStore, MastForestStore, TransactionMastStore};
 
     pub use crate::store::data_store::ClientDataStore;
     pub use crate::test_utils::*;

--- a/crates/rust-client/src/note/mod.rs
+++ b/crates/rust-client/src/note/mod.rs
@@ -106,6 +106,7 @@ pub use miden_protocol::note::{
 pub use miden_protocol::transaction::ToInputNoteCommitments;
 /// Raw access to `miden-standards` note modules for items not curated by `miden-client`.
 pub use miden_standards::note as standards;
+pub use miden_standards::note::costs::{NoteConsumptionCost, NoteCost};
 pub use miden_standards::note::{
     FeeSponsorshipNote,
     MintNote,

--- a/crates/rust-client/src/transaction/mod.rs
+++ b/crates/rust-client/src/transaction/mod.rs
@@ -172,6 +172,8 @@ pub use miden_protocol::transaction::{
     RawOutputNote,
     RawOutputNotes,
     TransactionArgs,
+    TransactionFee,
+    TransactionFeeError,
     TransactionId,
     TransactionInputs,
     TransactionKernel,


### PR DESCRIPTION
Re-exports more missing types that users might be interested in, mostly related to fees.