### PR TITLE
fix(cli): notes --send silently accepts addresses from the wrong network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [FIX][cli] `notes --send` now rejects a recipient address whose network doesn't match the client's configured network, instead of silently sending to it.
+
 ### Breaking Changes
 
 * [BREAKING][type][rust] Added the `TransactionRequestError::SwapNoteWithZeroAsset` variant, so exhaustive matches on `TransactionRequestError` must handle it ([#2459](https://github.com/0xMiden/rust-sdk/pull/2459)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- [FIX][cli] `notes --send` now rejects a recipient address whose network doesn't match the client's configured network, instead of silently sending to it.
+- [FIX][cli] `notes --send` now rejects a recipient address whose network doesn't match the client's configured network, instead of silently sending to it. ([#2525](https://github.com/0xMiden/rust-sdk/pull/2525)).
 
 ### Breaking Changes
 

--- a/bin/miden-cli/src/commands/notes.rs
+++ b/bin/miden-cli/src/commands/notes.rs
@@ -532,6 +532,7 @@ fn note_summary(
 mod tests {
     use miden_client::Word;
     use miden_client::account::AccountId;
+    use miden_client::address::{Address, NetworkId};
     use miden_client::note::{
         Note,
         NoteAssets,
@@ -570,5 +571,23 @@ mod tests {
 
         assert_eq!(summary.sender, sender.to_string());
         assert_eq!(summary.tag, tag.to_string());
+    }
+
+    /// `notes --send` must reject an address whose network doesn't match the client's
+    /// configured network. This checks the underlying decode step that the fix relies on:
+    /// encoding an address for one network and decoding it must not report a match against a
+    /// different network.
+    #[test]
+    fn decoded_address_network_differs_across_networks() {
+        let account_id =
+            AccountId::try_from(ACCOUNT_ID_REGULAR_PRIVATE_ACCOUNT_UPDATABLE_CODE).unwrap();
+        let address = Address::new(account_id);
+
+        let encoded_for_testnet = address.encode(NetworkId::Testnet);
+        let (decoded_network_id, _decoded_address) =
+            Address::decode(&encoded_for_testnet).unwrap();
+
+        assert_eq!(decoded_network_id, NetworkId::Testnet);
+        assert_ne!(decoded_network_id, NetworkId::Mainnet);
     }
 }

--- a/bin/miden-cli/src/commands/notes.rs
+++ b/bin/miden-cli/src/commands/notes.rs
@@ -584,8 +584,7 @@ mod tests {
         let address = Address::new(account_id);
 
         let encoded_for_testnet = address.encode(NetworkId::Testnet);
-        let (decoded_network_id, _decoded_address) =
-            Address::decode(&encoded_for_testnet).unwrap();
+        let (decoded_network_id, _decoded_address) = Address::decode(&encoded_for_testnet).unwrap();
 
         assert_eq!(decoded_network_id, NetworkId::Testnet);
         assert_ne!(decoded_network_id, NetworkId::Mainnet);

--- a/bin/miden-cli/src/commands/notes.rs
+++ b/bin/miden-cli/src/commands/notes.rs
@@ -577,10 +577,9 @@ mod tests {
         assert_eq!(summary.tag, tag.to_string());
     }
 
-    /// `notes --send` must reject an address whose network doesn't match the client's
-    /// configured network. This checks the underlying decode step that the fix relies on:
-    /// encoding an address for one network and decoding it must not report a match against a
-    /// different network.
+    /// `notes --send` must reject an address whose network doesn't match the client's configured
+    /// network. This checks the underlying decode step that the fix relies on: encoding an address
+    /// for one network and decoding it must not report a match against a different network.
     #[test]
     fn decoded_address_network_differs_across_networks() {
         let account_id =

--- a/bin/miden-cli/src/commands/notes.rs
+++ b/bin/miden-cli/src/commands/notes.rs
@@ -349,7 +349,14 @@ async fn send<AUTH: Keystore + Sync>(
     let note: Note = note_record
         .try_into()
         .map_err(|e| CliError::from(ClientError::NoteRecordConversionError(e)))?;
-    let (_netid, address) = Address::decode(address).map_err(|e| CliError::Input(e.to_string()))?;
+    let (address_network_id, address) =
+        Address::decode(address).map_err(|e| CliError::Input(e.to_string()))?;
+    let client_network_id = client.network_id().await?;
+    if address_network_id != client_network_id {
+        return Err(CliError::Input(format!(
+            "Address network `{address_network_id}` does not match configured network `{client_network_id}`",
+        )));
+    }
 
     match block_hint {
         Some(block_hint) => {


### PR DESCRIPTION
## Problem
`address add`, `address remove`, and `address encode` all validate that a
decoded bech32 address's network matches the client's configured network
(see `decode_account_address` in `commands/address.rs`). `notes --send`
uses the same `Address::decode()` call but discards the returned network
ID (`_netid`), so it silently accepts an address encoded for a different
Miden network (mainnet vs testnet vs devnet).

## Impact
A user pasting a testnet address into a mainnet client (or vice versa) gets
no error: `send_private_note`/`send_private_note_with_block_hint` proceeds
normally, but the note is effectively unreachable to the intended recipient
on the other network.

## Fix
Mirror the same network check already used in `address.rs`: compare the
decoded network ID against `client.network_id()` and return a clear
`CliError::Input` if they don't match.

## Repro (before fix)
1. `miden-client address encode <account> basic-wallet` on a **testnet**-configured client → copy the printed bech32 address.
2. On a **mainnet**-configured client: `miden-client notes --send <note-id> <that-address>` → succeeds with no error today.
3. After this fix: fails with ``Address network `mtst` does not match configured network `mm`.``

## Checklist
- [x] Forked from `next`, branch named per convention
- [x] Commit signed (GitHub web UI)
- [x] Commit message / code style follow conventions
- [x] CHANGELOG.md entry added